### PR TITLE
Detect logrus exit point when inspecting bugsnag stack

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "2.1.0"
 
 [[projects]]
+  digest = "1:512883404c2a99156e410e9880e3bb35ecccc0c07c1159eb204b5f3ef3c431b3"
+  name = "github.com/bitly/go-simplejson"
+  packages = ["."]
+  pruneopts = ""
+  revision = "aabad6e819789e569bd6aabf444c935aa9ba1e44"
+  version = "v0.5.0"
+
+[[projects]]
   digest = "1:4a7b6a852e018acafd79bf345944a9b2a332ebb968593ff36edadd3677ebb019"
   name = "github.com/bugsnag/bugsnag-go"
   packages = [
@@ -161,6 +169,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DataDog/datadog-go/statsd",
+    "github.com/bitly/go-simplejson",
     "github.com/bugsnag/bugsnag-go",
     "github.com/bugsnag/bugsnag-go/errors",
     "github.com/gorilla/mux",

--- a/logrusbugsnag/bugsnag_test.go
+++ b/logrusbugsnag/bugsnag_test.go
@@ -1,0 +1,157 @@
+package logrusbugsnag
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/bitly/go-simplejson"
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// Copied from bugsnag tests
+
+var roundTripper = &nilRoundTripper{}
+var postedJSON = make(chan []byte, 10)
+var testOnce sync.Once
+var testAPIKey = "166f5ad3590596f9aa8d601ea89af845"
+var errTest = errors.New("test error")
+
+type nilRoundTripper struct {
+	record bool
+}
+
+func (rt *nilRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if rt.record {
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		postedJSON <- body
+	}
+
+	return &http.Response{
+		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		StatusCode: http.StatusOK,
+	}, nil
+}
+
+func setup(record bool) {
+	roundTripper.record = record
+	testOnce.Do(func() {
+		l := logrus.New()
+		l.Out = ioutil.Discard
+
+		bugsnag.Configure(bugsnag.Configuration{
+			APIKey: testAPIKey,
+			Endpoints: bugsnag.Endpoints{
+				Notify: "",
+			},
+			Synchronous: true,
+			Transport:   roundTripper,
+			Logger:      l,
+		})
+	})
+}
+
+func BenchmarkHook_Fire(b *testing.B) {
+	setup(false)
+
+	l := logrus.New()
+	l.Out = ioutil.Discard
+
+	hook, err := NewBugsnagHook(nil)
+	assert.NoError(b, err)
+	l.Hooks.Add(hook)
+
+	b.Run("Error", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			l.Error("testing")
+		}
+	})
+
+	var doRecover = func() {
+		recover()
+	}
+
+	var doPanic = func() {
+		defer doRecover()
+		l.Panic("testing")
+	}
+
+	b.Run("Panic", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			doPanic()
+		}
+	})
+}
+
+func TestNewBugsnagHook(t *testing.T) {
+	setup(true)
+
+	l := logrus.New()
+	l.Out = ioutil.Discard
+
+	hook, err := NewBugsnagHook(nil)
+	assert.NoError(t, err)
+	l.Hooks.Add(hook)
+
+	t.Run("inline error", func(t *testing.T) {
+		t.Run("inline logging", func(t *testing.T) {
+			l.WithError(err).Error(errors.New("foo"))
+			json, err := simplejson.NewJson(<-postedJSON)
+			assert.NoError(t, err)
+
+			exception := json.Get("events").GetIndex(0).Get("exceptions").GetIndex(0)
+			assert.Equal(t, "*errors.errorString", exception.Get("errorClass").MustString())
+			assert.Equal(t, "foo", exception.Get("message").MustString())
+			assert.NotEqual(t, "triggerError", exception.Get("stacktrace").GetIndex(0).Get("method").MustString())
+			assert.Contains(t, exception.Get("stacktrace").GetIndex(0).Get("file").MustString(), "bugsnag_test.go")
+		})
+
+		t.Run("other function logging", func(t *testing.T) {
+			triggerError(l, errors.New("foo"))
+			json, err := simplejson.NewJson(<-postedJSON)
+			assert.NoError(t, err)
+
+			exception := json.Get("events").GetIndex(0).Get("exceptions").GetIndex(0)
+			assert.Equal(t, "*errors.errorString", exception.Get("errorClass").MustString())
+			assert.Equal(t, "foo", exception.Get("message").MustString())
+			assert.Equal(t, "triggerError", exception.Get("stacktrace").GetIndex(0).Get("method").MustString())
+		})
+	})
+
+	t.Run("prebuilt error", func(t *testing.T) {
+		t.Run("inline logging", func(t *testing.T) {
+			l.WithError(errTest).Error("test")
+			json, err := simplejson.NewJson(<-postedJSON)
+			assert.NoError(t, err)
+
+			exception := json.Get("events").GetIndex(0).Get("exceptions").GetIndex(0)
+			assert.Equal(t, "*errors.errorString", exception.Get("errorClass").MustString())
+			assert.Equal(t, "test error", exception.Get("message").MustString())
+			assert.NotEqual(t, "triggerError", exception.Get("stacktrace").GetIndex(0).Get("method").MustString())
+			assert.Contains(t, exception.Get("stacktrace").GetIndex(0).Get("file").MustString(), "bugsnag_test.go")
+		})
+
+		t.Run("other function logging", func(t *testing.T) {
+			triggerError(l, errTest)
+			json, err := simplejson.NewJson(<-postedJSON)
+			assert.NoError(t, err)
+
+			exception := json.Get("events").GetIndex(0).Get("exceptions").GetIndex(0)
+			assert.Equal(t, "*errors.errorString", exception.Get("errorClass").MustString())
+			assert.Equal(t, "test error", exception.Get("message").MustString())
+			assert.Equal(t, "triggerError", exception.Get("stacktrace").GetIndex(0).Get("method").MustString())
+		})
+	})
+}
+
+func triggerError(l *logrus.Logger, err error) {
+	l.WithError(err).Error("test")
+}


### PR DESCRIPTION
Benchmark without stack inspection:
```
BenchmarkHook_Fire/Error-8         	   50000	     27030 ns/op
BenchmarkHook_Fire/Panic-8         	   50000	     29087 ns/op
```

Benchmark with stack inspection (this patch):
```
BenchmarkHook_Fire/Error-8         	   50000	     29589 ns/op
BenchmarkHook_Fire/Panic-8         	   50000	     31179 ns/op
```

9% slower, seems acceptable for reliability.