### PR TITLE
Add a pprof Servlet

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -64,6 +64,30 @@
   version = "v3.1.2"
 
 [[projects]]
+  branch = "master"
+  digest = "1:1ad4c037735491fc9c7ae734f9ddf6bf3dd9505833ff76c28a3054fb884ff3cc"
+  name = "github.com/google/pprof"
+  packages = [
+    "driver",
+    "internal/binutils",
+    "internal/driver",
+    "internal/elfexec",
+    "internal/graph",
+    "internal/measurement",
+    "internal/plugin",
+    "internal/report",
+    "internal/symbolizer",
+    "internal/symbolz",
+    "internal/transport",
+    "profile",
+    "third_party/d3",
+    "third_party/d3flamegraph",
+    "third_party/svgpan",
+  ]
+  pruneopts = ""
+  revision = "b421f19a5c07fe0eb5b553c4c3d681fdfcb80f26"
+
+[[projects]]
   branch = "subrouter-match-err"
   digest = "1:88f974cc48e2ab70f8cd167443bee35de7e7b99e12a6d73aa86aaa37be2c5c52"
   name = "github.com/gorilla/mux"
@@ -71,6 +95,14 @@
   pruneopts = ""
   revision = "63803a6dfc26397890ca526fd51c5518b5311b0e"
   source = "https://github.com/lavoiesl/mux.git"
+
+[[projects]]
+  branch = "master"
+  digest = "1:375f95ad271c91ca806948bee3dbca17af8586f02f0548626da22fa21ab2646b"
+  name = "github.com/ianlancetaylor/demangle"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5e5cf60278f657d30daa329dd0e7e893b6b8f027"
 
 [[projects]]
   digest = "1:7ab38c15bd21e056e3115c8b526d201eaf74e0308da9370997c6b3c187115d36"
@@ -180,6 +212,7 @@
     "github.com/bradfitz/gomemcache/memcache",
     "github.com/bugsnag/bugsnag-go",
     "github.com/bugsnag/bugsnag-go/errors",
+    "github.com/google/pprof/driver",
     "github.com/gorilla/mux",
     "github.com/imdario/mergo",
     "github.com/nu7hatch/gouuid",

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -17,7 +17,7 @@ type Profiler interface {
 	End() error
 }
 
-func New(cpuFile string, memoryFile string) Profiler {
+func NewProfiler(cpuFile string, memoryFile string) Profiler {
 	var profilers []Profiler
 	if cpuFile != "" {
 		profilers = append(profilers, &cpuProfiler{filePath: cpuFile})

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -1,0 +1,19 @@
+package profiler_test
+
+import "github.com/Shopify/goose/profiler"
+
+func ExampleNewProfiler() {
+	cpuFile := "cpu.prof"
+	memoryFile := "memory.prof"
+
+	p := profiler.NewProfiler(cpuFile, memoryFile)
+	if err := p.Start(); err != nil {
+		panic(err)
+	}
+
+	// Do stuff
+
+	if err := p.End(); err != nil {
+		panic(err)
+	}
+}

--- a/profiler/servlet.go
+++ b/profiler/servlet.go
@@ -1,0 +1,47 @@
+package profiler
+
+import (
+	"net/http"
+	httppprof "net/http/pprof"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/Shopify/goose/srvutil"
+)
+
+// NewServlet returns a Servlet which can serve pprof requests
+//
+// /debug/pprof/ is the homepage
+// /debug/pprof/ui/ is the same homepage, but where all links point to a UI instead of raw downloads
+// /debug/pprof/*/ are the raw handlers
+// /debug/pprof/ui/*/ are the same handlers, but with a rendered UI
+func NewServlet() srvutil.Servlet {
+	s := &pprofServlet{}
+	return srvutil.PrefixServlet(s, "/debug/pprof")
+}
+
+type pprofServlet struct{}
+
+func (s *pprofServlet) RegisterRouting(r *mux.Router) {
+	r.StrictSlash(true)
+
+	r.HandleFunc("/cmdline", httppprof.Cmdline)
+	r.HandleFunc("/profile", httppprof.Profile)
+	r.HandleFunc("/symbol", httppprof.Symbol)
+	r.HandleFunc("/trace", httppprof.Trace)
+
+	r.HandleFunc("/ui/{profile}/{view}", pprofUIHandler)
+	r.HandleFunc("/ui/{profile}/", pprofUIHandler)
+
+	// Serve the same index as /pprof/, but because the path is /ui/, all links will be relative to that,
+	// translating to /pprof/ui/{profile}
+	r.HandleFunc("/ui/", func(w http.ResponseWriter, r *http.Request) {
+		// But we have to hide it from the Index, otherwise it will look for a "ui" profile
+		r.URL.Path = strings.TrimSuffix(r.URL.Path, "ui/")
+		httppprof.Index(w, r)
+	})
+
+	r.HandleFunc("/{profiler}", httppprof.Index)
+	r.HandleFunc("/", httppprof.Index)
+}

--- a/profiler/servlet_test.go
+++ b/profiler/servlet_test.go
@@ -1,0 +1,94 @@
+package profiler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewServlet(t *testing.T) {
+	s := NewServlet()
+	rt := mux.NewRouter()
+	s.RegisterRouting(rt)
+
+	t.Run("pprof", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/debug/pprof", nil)
+		rt.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "/debug/pprof/", w.Header().Get("location"))
+	})
+
+	t.Run("pprof/", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/debug/pprof/", nil)
+		rt.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "full goroutine stack dump")
+	})
+
+	t.Run("pprof/ui", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/debug/pprof/ui", nil)
+		rt.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "/debug/pprof/ui/", w.Header().Get("location"))
+	})
+
+	t.Run("pprof/ui/", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/debug/pprof/ui/", nil)
+		rt.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "full goroutine stack dump")
+	})
+
+	t.Run("pprof/ui/heap", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/debug/pprof/ui/heap?gc=1", nil)
+		rt.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "/debug/pprof/ui/heap/?gc=1", w.Header().Get("location"))
+	})
+
+	t.Run("pprof/ui/trace/", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/debug/pprof/ui/trace/", nil)
+		rt.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "/debug/pprof/trace/", w.Header().Get("location"))
+	})
+
+	t.Run("pprof/ui/heap/", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/debug/pprof/ui/heap/?si=alloc_objects", nil)
+		rt.ServeHTTP(w, r)
+
+		if w.Code == http.StatusNotImplemented {
+			// That's fine
+			assert.Contains(t, w.Body.String(), "Could not execute dot; may need to install graphviz")
+		} else {
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, w.Body.String(), "viewer(")
+			assert.Contains(t, w.Body.String(), "Type: alloc_objects")
+		}
+	})
+
+	t.Run("pprof/ui/profile/flamegraph", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/debug/pprof/ui/profile/flamegraph?seconds=1", nil)
+		rt.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "var data = {")
+	})
+}

--- a/profiler/ui.go
+++ b/profiler/ui.go
@@ -1,0 +1,185 @@
+package profiler
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	httppprof "net/http/pprof"
+	"os"
+	"runtime/pprof"
+	"strings"
+
+	"github.com/google/pprof/driver"
+	"github.com/gorilla/mux"
+)
+
+func pprofUIHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+
+	f, err := ioutil.TempFile("", "pprof.*.pb")
+	if err != nil {
+		log(ctx, err).Error("error creating temporary file")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log(ctx, err).WithField("file", f.Name()).Debug("writing pprof to temp file")
+	defer removeFile(ctx, f.Name())
+
+	q := r.URL.Query()
+	q.Del("debug") // debug doesn't make sense for UI
+	r.URL.RawQuery = q.Encode()
+
+	// Record what would normally be served to the user in a file such that it can be passed to the UI renderer
+	rec := httptest.NewRecorder()
+	profile := vars["profile"]
+	if profile == "profile" {
+		httppprof.Profile(rec, r)
+	} else {
+		// Check validity of the profile
+		p := pprof.Lookup(profile)
+		if p == nil {
+			// The /debug/pprof/ui page has links to all the profiles, but some are not supported, so redirect to non-ui.
+			log(ctx, nil).WithField("profile", profile).Warn("unknown profile")
+			url := strings.Replace(r.URL.Path, "/ui/", "/", 1)
+			http.Redirect(w, r, url, http.StatusMovedPermanently)
+			return
+		}
+
+		httppprof.Handler(profile).ServeHTTP(rec, r)
+	}
+
+	if rec.Code != 0 && rec.Code != http.StatusOK {
+		log(ctx, err).Error("error recording pprof")
+		http.Error(w, rec.Body.String(), rec.Code)
+		return
+	}
+	if _, err = rec.Body.WriteTo(f); err != nil {
+		log(ctx, err).Error("error closing file")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := serveUI(ctx, w, r, f.Name()); err != nil {
+		log(ctx, err).Warn("error serving pprof ui")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func serveUI(ctx context.Context, w http.ResponseWriter, r *http.Request, inputFile string) error {
+	vars := mux.Vars(r)
+	return driver.PProf(&driver.Options{
+		UI: &dummyUI{ctx: ctx},
+		Flagset: &inlineFlagset{
+			strings: map[string]string{
+				// Meaningless, but force it to behave like a web server
+				"http": "localhost:0",
+			},
+			args: []string{inputFile},
+		},
+		HTTPServer: func(args *driver.HTTPServerArgs) error {
+			path := "/" + vars["view"]
+			handler, ok := args.Handlers[path]
+			if !ok {
+				log(ctx, nil).Warn("unknown view")
+				return errors.New("unknown view: " + vars["view"])
+			}
+			handler.ServeHTTP(w, r)
+			return nil
+		},
+	})
+}
+
+func removeFile(ctx context.Context, path string) {
+	if err := os.Remove(path); err != nil {
+		log(ctx, err).Error("unable to remove file")
+	}
+}
+
+// inlineFlagset implements the plugin.FlagSet interface.
+// Adapted from testFlags in github.com/google/pprof/internal/driver
+type inlineFlagset struct {
+	strings map[string]string
+	args    []string
+}
+
+func (f inlineFlagset) AddExtraUsage(_ string) {}
+
+func (inlineFlagset) ExtraUsage() string { return "" }
+
+func (f inlineFlagset) Bool(_ string, d bool, _ string) *bool {
+	return &d
+}
+
+func (f inlineFlagset) Int(_ string, d int, _ string) *int {
+	return &d
+}
+
+func (f inlineFlagset) Float64(_ string, d float64, _ string) *float64 {
+	return &d
+}
+
+func (f inlineFlagset) String(s, d, _ string) *string {
+	if t, ok := f.strings[s]; ok {
+		return &t
+	}
+	return &d
+}
+
+func (f inlineFlagset) BoolVar(p *bool, _ string, d bool, _ string) {
+	*p = d
+}
+
+func (f inlineFlagset) IntVar(p *int, _ string, d int, _ string) {
+	*p = d
+}
+
+func (f inlineFlagset) Float64Var(p *float64, _ string, d float64, _ string) {
+	*p = d
+}
+
+func (f inlineFlagset) StringVar(p *string, s, d, _ string) {
+	if t, ok := f.strings[s]; ok {
+		*p = t
+	} else {
+		*p = d
+	}
+}
+
+func (f inlineFlagset) StringList(s, d, _ string) *[]*string {
+	return &[]*string{}
+}
+
+func (f inlineFlagset) Parse(func()) []string {
+	return f.args
+}
+
+// dummyUI implements a basic UI such that WantBrowser is false and we has a custom logger
+type dummyUI struct {
+	ctx context.Context
+}
+
+func (ui *dummyUI) ReadLine(prompt string) (string, error) {
+	return "", nil
+}
+
+func (ui *dummyUI) Print(args ...interface{}) {
+	log(ui.ctx, nil).Print(args...)
+}
+
+func (ui *dummyUI) PrintErr(args ...interface{}) {
+	log(ui.ctx, nil).Warn(args...)
+}
+
+func (ui *dummyUI) IsTerminal() bool {
+	return false
+}
+
+func (ui *dummyUI) WantBrowser() bool {
+	return false
+}
+
+func (ui *dummyUI) SetAutoComplete(func(string) string) {
+}


### PR DESCRIPTION
- `/debug/pprof/` is the homepage
- `/debug/pprof/ui/` is the same homepage, but where all links point to a UI instead of raw downloads
- `/debug/pprof/*/` are the raw handlers
- `/debug/pprof/ui/*/` are the same handlers, but with a rendered UI

With this, you can view the rendered profiles directly from a running server.
No need to download, then invoke `go tool pprof -http`.

Advantages compares to Stackdriver Profiler:
1. It’s that one machine, which can be useful for intermittent hangs
2. It’s 100% sampling, right there, not delayed
3. You can run it locally
4. It supports _all_ the the pprof profiles and _all_ the views (call graph and source, not just flame graph)

Caveats: 
1. Be mindful with `profile`, it runs the CPU profiles for 30 seconds by default.
2. Be sure those routes are protected so it doesn't leak sensitive information about your codebase