### PR TITLE
Make err optional to log(ctx)

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,11 +13,19 @@ type causer interface {
 
 var GlobalFields = logrus.Fields{}
 
-type Logger func(Valuer, error) *logrus.Entry
+type Logger func(Valuer, ...error) *logrus.Entry
 
 func New(name string) Logger {
-	return func(ctx Valuer, err error) *logrus.Entry {
-		return ContextLog(ctx, err, nil).WithField("component", name)
+	return func(ctx Valuer, err ...error) *logrus.Entry {
+		switch len(err) {
+		case 0:
+			return ContextLog(ctx, nil, nil).WithField("component", name)
+		case 1:
+			return ContextLog(ctx, err[0], nil).WithField("component", name)
+		default:
+			ContextLog(ctx, nil, nil).WithField("component", name).Errorf("%d errors provided, expected 0 or 1", len(err))
+			return ContextLog(ctx, nil, nil).WithField("component", name)
+		}
 	}
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -17,19 +18,14 @@ type Logger func(Valuer, ...error) *logrus.Entry
 
 func New(name string) Logger {
 	return func(ctx Valuer, err ...error) *logrus.Entry {
-		switch len(err) {
-		case 0:
-			return ContextLog(ctx, nil, nil).WithField("component", name)
-		case 1:
-			return ContextLog(ctx, err[0], nil).WithField("component", name)
-		default:
-			ContextLog(ctx, nil, nil).WithField("component", name).Errorf("%d errors provided, expected 0 or 1", len(err))
-			return ContextLog(ctx, nil, nil).WithField("component", name)
+		if len(err) == 1 && err[0] == nil {
+			err = nil
 		}
+		return ContextLog(ctx, err, nil).WithField("component", name)
 	}
 }
 
-func ContextLog(ctx Valuer, err error, entry *logrus.Entry) *logrus.Entry {
+func ContextLog(ctx Valuer, err []error, entry *logrus.Entry) *logrus.Entry {
 	if entry == nil {
 		entry = logrus.NewEntry(logrus.StandardLogger())
 	}
@@ -39,11 +35,20 @@ func ContextLog(ctx Valuer, err error, entry *logrus.Entry) *logrus.Entry {
 		entry = entry.WithFields(getLoggableValues(ctx))
 	}
 
-	if err != nil {
-		entry = entry.WithField("error", err)
+	if len(err) != 0 {
+		err0 := err[0]
+		entry = entry.WithField("error", err0)
 
-		if _, ok := err.(causer); ok {
-			entry = entry.WithField("cause", errors.Cause(err))
+		if _, ok := err0.(causer); ok {
+			entry = entry.WithField("cause", errors.Cause(err0))
+		}
+
+		for i, errX := range err[1:] {
+			entry = entry.WithField(fmt.Sprintf("error%d", i+1), errX)
+
+			if _, ok := errX.(causer); ok {
+				entry = entry.WithField(fmt.Sprintf("cause%d", i+1), errors.Cause(errX))
+			}
 		}
 	}
 

--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -103,8 +103,11 @@ func buildLogger() (logger.Logger, *syncio.Buffer) {
 	}
 	entry := logrus.NewEntry(logrusLogger)
 
-	log := func(ctx logger.Valuer, err error) *logrus.Entry {
-		return logger.ContextLog(ctx, err, entry)
+	log := func(ctx logger.Valuer, err ...error) *logrus.Entry {
+		if len(err) == 0 {
+			return logger.ContextLog(ctx, nil, entry)
+		}
+		return logger.ContextLog(ctx, err[0], entry)
 	}
 
 	return log, buf

--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -104,10 +104,7 @@ func buildLogger() (logger.Logger, *syncio.Buffer) {
 	entry := logrus.NewEntry(logrusLogger)
 
 	log := func(ctx logger.Valuer, err ...error) *logrus.Entry {
-		if len(err) == 0 {
-			return logger.ContextLog(ctx, nil, entry)
-		}
-		return logger.ContextLog(ctx, err[0], entry)
+		return logger.ContextLog(ctx, nil, entry)
 	}
 
 	return log, buf


### PR DESCRIPTION
It's a bit weird to write `log(ctx, nil).Info("foo")` everywhere when you want to log but don't have an error. This PR makes it so that you can write `log(ctx).Info("foo")` instead, making the `err` optional.

Optional arguments through variadic lists can be a bit weird I guess, but I think it fits here, since `logger.New` is a convenience wrapper round `logger.ContextLog`.

This is a breaking change (the `logger.Logger` type has changed). I'm not sure what the policy is on breaking changes.

The test failures seem unrelated - it passes `make test style` locally.