### PR TITLE
Abort server listener before accepting new connections

### DIFF
--- a/srvutil/server.go
+++ b/srvutil/server.go
@@ -80,6 +80,7 @@ func (c *server) Run() error {
 
 	go func() {
 		<-c.tomb.Dying()
+		log(ctx, c.tomb.Err()).Info("shutting down server")
 
 		// Call Shutdown to make allow in-flight requests to gracefully complete
 		ctx := context.Background()

--- a/srvutil/server.go
+++ b/srvutil/server.go
@@ -92,17 +92,17 @@ type stoppableKeepaliveListener struct {
 
 func (ln stoppableKeepaliveListener) Accept() (net.Conn, error) {
 	for {
-		if err := ln.SetDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
-			return nil, err
-		}
-
-		tc, err := ln.AcceptTCP()
-
 		select {
 		case <-ln.tomb.Dying():
 			return nil, ErrStopped
 		default:
 		}
+
+		if err := ln.SetDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+			return nil, err
+		}
+
+		tc, err := ln.AcceptTCP()
 
 		if err != nil {
 			netErr, ok := err.(net.Error)

--- a/srvutil/server.go
+++ b/srvutil/server.go
@@ -82,7 +82,7 @@ func (c *server) Run() error {
 		<-c.tomb.Dying()
 		log(ctx, c.tomb.Err()).Info("shutting down server")
 
-		// Call Shutdown to make allow in-flight requests to gracefully complete
+		// Call Shutdown to allow in-flight requests to gracefully complete.
 		ctx := context.Background()
 		err := c.Shutdown(ctx)
 		if err != nil {

--- a/srvutil/server.go
+++ b/srvutil/server.go
@@ -2,7 +2,6 @@ package srvutil
 
 import (
 	"context"
-	"errors"
 	"net"
 	"net/http"
 	"time"
@@ -17,9 +16,6 @@ import (
 const (
 	keepAlivePeriod = 3 * time.Minute
 )
-
-// ErrStopped indicates the server was stopped by a request to the Tomb.
-var ErrStopped = errors.New("stopped")
 
 // Server wraps an http.Server to make it runnable and stoppable
 // If its tomb dies, the server will be stopped
@@ -105,7 +101,7 @@ type stoppableKeepaliveListener struct {
 func (ln stoppableKeepaliveListener) Accept() (net.Conn, error) {
 	for {
 		if !ln.tomb.Alive() {
-			return nil, ErrStopped
+			return nil, http.ErrServerClosed
 		}
 
 		if err := ln.SetDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {

--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -85,11 +85,9 @@ func TestNewServer(t *testing.T) {
 
 	// No longer works
 	res, err = http.Get(u)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-	body, err = ioutil.ReadAll(res.Body)
-	assert.NoError(t, err)
-	assert.Equal(t, "great success", string(body))
+	errMsg := fmt.Sprintf("Get %s: dial tcp %s: connect: connection refused", u, s.Addr().String())
+	assert.EqualError(t, err, errMsg)
+	assert.Nil(t, res)
 }
 
 func buildLogger() (logger.Logger, *syncio.Buffer) {

--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -90,6 +90,62 @@ func TestNewServer(t *testing.T) {
 	assert.Nil(t, res)
 }
 
+func TestStoppableKeepaliveListener_Accept(t *testing.T) {
+	testLog, logOutput := buildLogger()
+	origLog := log
+	log = testLog
+	defer func() { log = origLog }()
+
+	handling := make(chan struct{})
+
+	tb := &tomb.Tomb{}
+	sl := FuncServlet("/", func(res http.ResponseWriter, req *http.Request) {
+		// Notify that we are handling this request
+		close(handling)
+
+		// Wait for the server to be ask to shutdown
+		<-tb.Dying()
+
+		res.WriteHeader(http.StatusOK)
+		_, err := res.Write([]byte("great success"))
+		assert.NoError(t, err)
+	})
+	s := NewServer(tb, "127.0.0.1:0", sl)
+	safely.Run(s)
+
+	u := "http://" + s.Addr().String()
+	t.Logf("test server running on %s", u)
+
+	done := make(chan struct{})
+
+	go func() {
+		res, err := http.Get(u) // This will block on tb.Dying()
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		body, err := ioutil.ReadAll(res.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "great success", string(body))
+		close(done)
+	}()
+
+	<-handling
+	assert.NotContains(t, logOutput.String(), fmt.Sprintf("level=debug msg=\"stopped server\" addr=\"127.0.0.1:%d\" bind=\"127.0.0.1:0\"", s.Addr().Port))
+
+	tb.Kill(errors.New("testing"))
+
+	<-done
+	assert.Contains(t, logOutput.String(), fmt.Sprintf("level=info msg=\"shutting down server\" addr=\"127.0.0.1:%d\" bind=\"127.0.0.1:0\"", s.Addr().Port))
+
+	<-tb.Dead()
+	assert.Contains(t, logOutput.String(), fmt.Sprintf("level=debug msg=\"stopped server\" addr=\"127.0.0.1:%d\" bind=\"127.0.0.1:0\"", s.Addr().Port))
+
+	// No longer works
+	res, err := http.Get(u)
+	errMsg := fmt.Sprintf("Get %s: dial tcp %s: connect: connection refused", u, s.Addr().String())
+	assert.EqualError(t, err, errMsg)
+	assert.Nil(t, res)
+}
+
 func buildLogger() (logger.Logger, *syncio.Buffer) {
 	buf := syncio.NewBuffer(nil)
 	logrusLogger := logrus.New()


### PR DESCRIPTION
Please correct me if my understanding is wrong, but without this change, I believe the server listener can accept a new TCP connection but then immediately exit. That TCP connection will for a short while be established (as seen by the client), but the server will not handle it.