### PR TITLE
Request logging as INFO

### DIFF
--- a/srvutil/metrics.go
+++ b/srvutil/metrics.go
@@ -60,7 +60,7 @@ func RequestMetricsMiddleware(next http.Handler) http.Handler {
 		log(ctx, nil).
 			WithField("method", r.Method).
 			WithField("headers", headers).
-			Debug("http request")
+			Info("http request")
 
 		metrics.HTTPRequest.Time(ctx, func() error {
 			next.ServeHTTP(recorder, r)
@@ -74,6 +74,6 @@ func RequestMetricsMiddleware(next http.Handler) http.Handler {
 
 		log(ctx, nil).
 			WithField("headers", headers).
-			Debug("http response")
+			Info("http response")
 	})
 }

--- a/srvutil/metrics.go
+++ b/srvutil/metrics.go
@@ -1,9 +1,9 @@
 package srvutil
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -50,7 +50,7 @@ func RequestMetricsMiddleware(next http.Handler) http.Handler {
 		ctx = statsd.WatchingTagLoggable(ctx, recorder)
 		r = r.WithContext(ctx)
 
-		headers := &bytes.Buffer{}
+		headers := &strings.Builder{}
 		// Ignore headers that may contains sensitive information.
 		r.Header.WriteSubset(headers, map[string]bool{
 			"Authorization": true,
@@ -67,7 +67,7 @@ func RequestMetricsMiddleware(next http.Handler) http.Handler {
 			return nil
 		})
 
-		headers = &bytes.Buffer{}
+		headers = &strings.Builder{}
 		w.Header().WriteSubset(headers, map[string]bool{
 			"Set-Cookie": true,
 		})


### PR DESCRIPTION
I've found these logs to be very useful also in production. (We could make the level configurable if someone disagrees).

I also changed to a `strings.Builder` for the header extraction; it seems that `Header.WriteSubset` prefers things with a `WriteString` method (adds wrapper otherwise).