### PR TITLE
Report context canceled when a shell is canceled

### DIFF
--- a/shell/shell.go
+++ b/shell/shell.go
@@ -42,15 +42,17 @@ type wrapper struct {
 	ctx context.Context
 	cmd *exec.Cmd
 
-	path            string
-	dir             string
-	args            []string
-	env             []string
-	osEnv           bool
-	sysProcAttr     *syscall.SysProcAttr
-	ctxCancellation bool
+	path        string
+	dir         string
+	args        []string
+	env         []string
+	osEnv       bool
+	sysProcAttr *syscall.SysProcAttr
 
-	// When a context is provided and it is cancelled while the process is
+	ctxCancellation bool
+	killedByCancel  uint32 // Number of times the command was "killed" after the context was canceled.
+
+	// When a context is provided and it is canceled while the process is
 	// running, we send SIGTERM to the process. if, after this period, the
 	// process is still running, we send SIGKILL. If left unspecified, the
 	// default is 3 seconds.

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -216,7 +216,7 @@ func TestCommandContextCancels(t *testing.T) {
 	cancel()
 
 	err = cmd.Wait()
-	assert.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
 	ws := cmd.Cmd().ProcessState.Sys().(syscall.WaitStatus)
 	sig := ws.Signal()
 	assert.Equal(t, "terminated", sig.String())
@@ -246,7 +246,7 @@ func TestCommandForceKills(t *testing.T) {
 	cancel()
 
 	err = cmd.Wait()
-	assert.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
 	ws := cmd.Cmd().ProcessState.Sys().(syscall.WaitStatus)
 	sig := ws.Signal()
 	assert.Equal(t, "killed", sig.String())


### PR DESCRIPTION
Normally, the cmd would report it was "terminated".
In reality, the context was canceled and we gracefully stopped it, report as such.