### PR TITLE
Pass along context from log entry to bugsnag hook

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -209,12 +209,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:9d57e200ef5ccc4217fe0a34287308bac652435e7c6513f6263e0493d2245c56"
+  digest = "1:b73fe282e350b3ef2c71d8ff08e929e0b9670b1bb5b7fde1d3c1b4cd6e6dc8b1"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = ""
-  revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
-  version = "v1.2.0"
+  revision = "dae0fa8d5b0c810a8ab733fbd5510c7cae84eca4"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,6 +28,10 @@
   name = "github.com/stretchr/testify"
   version = ">= 1.2.1"
 
+[[constraint]]
+  name = "github.com/sirupsen/logrus"
+  version = ">= 1.4.0"
+
 [[override]]
   name = "github.com/gorilla/mux"
   branch = "subrouter-match-err"

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -33,6 +33,9 @@ func ContextLog(ctx Valuer, err []error, entry *logrus.Entry) *logrus.Entry {
 
 	if ctx != nil {
 		entry = entry.WithFields(getLoggableValues(ctx))
+		if ctx, ok := ctx.(context.Context); ok {
+			entry = entry.WithContext(ctx)
+		}
 	}
 
 	if len(err) != 0 {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type contextKeyType string
+
 func buildLogger() (Logger, *bytes.Buffer) {
 	buf := bytes.NewBuffer(nil)
 	logrusLogger := logrus.New()
@@ -110,7 +112,8 @@ func TestContextLog(t *testing.T) {
 
 	GlobalFields["testKey"] = "value"
 
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), contextKeyType("ctxValue"), "value")
+
 	ctx = WithField(ctx, "bar", "baz")
 	entry := logger(ctx, nil).WithField("a", "b")
 	assert.Equal(t, logrus.Fields{
@@ -119,6 +122,7 @@ func TestContextLog(t *testing.T) {
 		"a":         "b",
 		"testKey":   "value",
 	}, entry.Data)
+	assert.Equal(t, ctx, entry.Context)
 }
 
 func TestLogIfError(t *testing.T) {

--- a/logrusbugsnag/bugsnag.go
+++ b/logrusbugsnag/bugsnag.go
@@ -94,7 +94,9 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 	}
 
 	errWithStack := bugsnag_errors.New(notifyErr, skipFrames)
-	bugsnagErr := bugsnag.Notify(errWithStack, metadata)
+
+	// Pass in our own metadata as well as the entry context, which might contain more data that Bugsnag can extract.
+	bugsnagErr := bugsnag.Notify(errWithStack, metadata, entry.Context)
 	if bugsnagErr != nil {
 		return ErrBugsnagSendFailed{bugsnagErr}
 	}


### PR DESCRIPTION
This depends on https://github.com/sirupsen/logrus/pull/919, see that PR for rationale. I'll remove the Gopkg.toml package override before merging.