### PR TITLE
Add Redact util, and use it when logging http request and response headers

### DIFF
--- a/redact/redact.go
+++ b/redact/redact.go
@@ -1,0 +1,59 @@
+package redact
+
+import (
+	"net/http"
+	"strings"
+)
+
+var GlobalSensitiveSubstrings = []string{
+	"authorization",
+	"cookie",
+	"token",
+	"password",
+	"secret",
+}
+
+func AddSensitiveSubstring(substrings ...string) {
+	lowerSubstrings := make([]string, len(substrings))
+	for i, s := range substrings {
+		lowerSubstrings[i] = strings.ToLower(s)
+	}
+	GlobalSensitiveSubstrings = append(GlobalSensitiveSubstrings, lowerSubstrings...)
+}
+
+func IsSensitive(key string) bool {
+	for _, sensitiveKey := range GlobalSensitiveSubstrings {
+		if strings.Contains(strings.ToLower(key), sensitiveKey) {
+			return true
+		}
+	}
+	return false
+}
+
+func Map(data map[string]interface{}) map[string]interface{} {
+	redactedData := make(map[string]interface{}, len(data))
+
+	for key, value := range data {
+		if IsSensitive(key) {
+			redactedData[key] = "[FILTERED]"
+		} else {
+			redactedData[key] = value
+		}
+	}
+
+	return redactedData
+}
+
+func Headers(headers http.Header) map[string]string {
+	redactedData := make(map[string]string, len(headers))
+
+	for key, value := range headers {
+		if IsSensitive(key) {
+			redactedData[key] = "[FILTERED]"
+		} else {
+			redactedData[key] = strings.Join(value, ",")
+		}
+	}
+
+	return redactedData
+}

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -1,0 +1,109 @@
+package redact
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMap(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		input          map[string]interface{}
+		expectedResult map[string]interface{}
+	}{
+		{
+			"empty map",
+			map[string]interface{}{},
+			map[string]interface{}{},
+		},
+
+		{
+			"sensitive",
+			map[string]interface{}{
+				"AuTHORization": "foo",
+				"keep this":     123123123,
+				"some_password": "s3cr3t",
+				"idToken":       "aldsfjalsdfj",
+			},
+			map[string]interface{}{
+				"AuTHORization": "[FILTERED]",
+				"keep this":     123123123,
+				"some_password": "[FILTERED]",
+				"idToken":       "[FILTERED]",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := Map(tc.input)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestMapCustomSubstrings(t *testing.T) {
+	oldSensitiveSubstrings := make([]string, len(GlobalSensitiveSubstrings))
+	copy(oldSensitiveSubstrings, GlobalSensitiveSubstrings)
+	defer func() {
+		GlobalSensitiveSubstrings = oldSensitiveSubstrings
+	}()
+
+	data := map[string]interface{}{"foo": "bar", "123": 456}
+
+	require.Equal(t, map[string]interface{}{"foo": "bar", "123": 456}, Map(data))
+
+	AddSensitiveSubstring("Foo")
+
+	require.Equal(t, map[string]interface{}{"foo": "[FILTERED]", "123": 456}, Map(data))
+
+	require.Equal(t, []string{
+		"authorization",
+		"cookie",
+		"token",
+		"password",
+		"secret",
+		"foo",
+	}, GlobalSensitiveSubstrings)
+}
+
+func TestHeaders(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		input          http.Header
+		expectedResult map[string]string
+	}{
+		{
+			"empty header",
+			http.Header{},
+			map[string]string{},
+		},
+
+		{
+			"sensitive",
+			http.Header{
+				"AuTHORization": []string{"foo"},
+				"keep this":     []string{"123123123"},
+				"some_password": []string{"s3cr3t"},
+				"idToken":       []string{"aldsfjalsdfj"},
+				"Many-Things":   []string{"one", "two", "three"},
+			},
+			map[string]string{
+				"AuTHORization": "[FILTERED]",
+				"keep this":     "123123123",
+				"some_password": "[FILTERED]",
+				"idToken":       "[FILTERED]",
+				"Many-Things":   "one,two,three",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := Headers(tc.input)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}

--- a/srvutil/metrics_test.go
+++ b/srvutil/metrics_test.go
@@ -71,9 +71,10 @@ func TestRequestMetricsMiddleware(t *testing.T) {
 	assert.Equal(t, []string{"route:/hello/@name", "route_name:world", "statusClass:2xx", "statusCode:200", "success:true"}, recordedTags)
 
 	output := strings.ToLower(logging.String())
-	assert.Contains(t, output, "foo: bar\\r\\n")
-	assert.Contains(t, output, "foo: baz\\r\\n")
-	assert.NotContains(t, output, "authorization: secret\\r\\n")
-	assert.NotContains(t, output, "cookie: secret\\r\\n")
-	assert.NotContains(t, output, "set-cookie: secret\\r\\n")
+	assert.Contains(t, output, "foo:bar")
+	assert.Contains(t, output, "foo:baz")
+	assert.NotContains(t, output, "secret")
+	assert.Contains(t, output, "authorization:[filtered]")
+	assert.Contains(t, output, "cookie:[filtered]")
+	assert.Contains(t, output, "set-cookie:[filtered]")
 }


### PR DESCRIPTION
I've found this to be useful in a bunch of places. I made the list of `SensitiveFields` exported so that applications can add and remove to it as they wish (perhaps we should have a better API for that?).