### PR TITLE
Add RealIPMiddleware to set r.RemoteAddr from X-Real-IP

### DIFF
--- a/srvutil/real_ip.go
+++ b/srvutil/real_ip.go
@@ -1,0 +1,21 @@
+package srvutil
+
+import (
+	"net/http"
+)
+
+const RealIPHeaderKey = "X-Real-IP"
+
+func RealIPMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			realIP := r.Header.Get(RealIPHeaderKey)
+
+			if realIP != "" {
+				r.RemoteAddr = realIP
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/srvutil/real_ip_test.go
+++ b/srvutil/real_ip_test.go
@@ -1,0 +1,37 @@
+package srvutil_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Shopify/goose/srvutil"
+)
+
+func ExampleRealIPMiddleware() {
+	r := mux.NewRouter()
+	r.Use(srvutil.RealIPMiddleware())
+}
+
+func TestRealIPMiddleware(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "RemoteAddr: %s", r.RemoteAddr)
+	})
+	r.Use(srvutil.RealIPMiddleware())
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/", nil)
+	assert.NoError(t, err)
+	req.Header.Set("X-Real-IP", "127.0.0.17")
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "RemoteAddr: 127.0.0.17", w.Body.String())
+}


### PR DESCRIPTION
`http.Request.RemoteAddr` is used e.g. by Bugsnag, so it's nice to set it appropriately. Should only be used when the application is behind a trusted proxy that sets the `X-Real-IP` header. The middleware could be adjusted to work with e.g. `X-Forwarded-For` too, when we have the use-case.