### PR TITLE
Use Go 1.12 locally + add as target on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ matrix:
       env: TARGET=test
     - name: "1.11.x unit tests"
       go: "1.11.x"
+      env: TARGET=test
+    - name: "1.12.x unit tests"
+      go: "1.12.x"
       env: TARGET=coverage
     - name: "Linting"
-      go: "1.11.x"
+      go: "1.12.x"
       env: TARGET=style
 before_install:
   # Use authentication for higher limits with go.googlesource.com

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,7 +34,8 @@
   revision = "bc664df9673713a0ccf26e3b55a673ec7301088b"
 
 [[projects]]
-  digest = "1:4a7b6a852e018acafd79bf345944a9b2a332ebb968593ff36edadd3677ebb019"
+  branch = "fix-go-112-test-failures"
+  digest = "1:e862d1405cc878d13e94de4e579e61f52af1510932b01e7be935cdc7dff81094"
   name = "github.com/bugsnag/bugsnag-go"
   packages = [
     ".",
@@ -44,8 +45,7 @@
     "sessions",
   ]
   pruneopts = ""
-  revision = "834d8fee64233ea79b0389ad7a5a438261788f66"
-  version = "v1.4.0"
+  revision = "57eeb790f058669b397c56c6615ffd46c902655c"
 
 [[projects]]
   digest = "1:dabac4ebc1a1ab0db927cc26be0bd5a5a31f846a8afee196b932056a345fee97"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 [[constraint]]
   name = "github.com/bugsnag/bugsnag-go"
-  version = ">= 1.3.1"
+  branch = "fix-go-112-test-failures"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ name: goose
 
 up:
   - go:
-      version: "1.11.2"
+      version: "1.12"
       tools:
         - github.com/alecthomas/gometalinter
         # gosumcheck is not installed by gometalinter


### PR DESCRIPTION
I'm not sure if upgrading from 1.10 -> 1.11 or 1.12 is difficult for some applications. When do you think we can remove the 1.10 test target?