### PR TITLE
Ignore errors if deleting a memcache entry in sharedstore

### DIFF
--- a/sharedstore/memcache_client.go
+++ b/sharedstore/memcache_client.go
@@ -82,5 +82,10 @@ func (w *memcacheClientWrapper) Add(key string, item *Item) error {
 }
 
 func (w *memcacheClientWrapper) Delete(key string) error {
-	return w.client.Delete(key)
+	err := w.client.Delete(key)
+	if err == memcache.ErrCacheMiss {
+		// Deleting a missing entry is not an actual issue.
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
Memcache does not provide guarantees that the entry are persistent.
Therefore, attempting to delete an entry that no longer exists is perfectly valid.