### PR TITLE
Add bugnsag wrapper lib

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -219,7 +219,10 @@
 [[projects]]
   digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
   pruneopts = ""
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
@@ -239,6 +242,10 @@
   packages = [
     "context",
     "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
   ]
   pruneopts = ""
   revision = "c10e9556a7bc0e7c942242b606f0acf024ad5d6a"
@@ -268,6 +275,29 @@
   ]
   pruneopts = ""
   revision = "9b800f95dbbc54abff0acf7ee32d88ba4e328c89"
+
+[[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = ""
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   digest = "1:bc09e719c4e2a15d17163f5272d9a3131c45d77542b7fdc53ff518815bc19ab3"
@@ -305,6 +335,7 @@
     "github.com/bradfitz/gomemcache/memcache",
     "github.com/bugsnag/bugsnag-go",
     "github.com/bugsnag/bugsnag-go/errors",
+    "github.com/bugsnag/panicwrap",
     "github.com/google/go-github/github",
     "github.com/google/pprof/driver",
     "github.com/gorilla/mux",
@@ -315,6 +346,8 @@
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "golang.org/x/net/http2",
     "golang.org/x/oauth2",
     "golang.org/x/oauth2/github",
     "golang.org/x/oauth2/google",

--- a/bugsnag/bugsnag.go
+++ b/bugsnag/bugsnag.go
@@ -1,4 +1,3 @@
-// This file defines the static APIs which can be accessed directly from the bugsnag package
 package bugsnag
 
 import (
@@ -6,13 +5,15 @@ import (
 )
 
 var (
-	def = NewBugsnagger(&bugsnaggo.Config, bugsnaggo.Notify)
+	def = newBugsnagger(&bugsnaggo.Config, bugsnaggo.Notify)
 )
 
 // TabWriter defines the interface to be implemented by the different client objects that want custom decorated bugsnag tabs
 type TabWriter interface {
 	CreateBugsnagTab() Tab
 }
+
+// These define the static APIs which can be accessed directly from the bugsnag package
 
 func Notify(err error, rawData ...interface{}) {
 	def.Notify(err, rawData...)

--- a/bugsnag/bugsnag.go
+++ b/bugsnag/bugsnag.go
@@ -1,0 +1,35 @@
+// This file defines the static APIs which can be accessed directly from the bugsnag package
+package bugsnag
+
+import (
+	bugsnaggo "github.com/bugsnag/bugsnag-go"
+)
+
+var (
+	def = NewBugsnagger(&bugsnaggo.Config, bugsnaggo.Notify)
+)
+
+// TabWriter defines the interface to be implemented by the different client objects that want custom decorated bugsnag tabs
+type TabWriter interface {
+	CreateBugsnagTab() Tab
+}
+
+func Notify(err error, rawData ...interface{}) {
+	def.Notify(err, rawData...)
+}
+
+func AutoNotify(rawData ...interface{}) {
+	def.AutoNotify(rawData...)
+}
+
+func AutoRecover(rawData ...interface{}) {
+	def.AutoRecover(rawData...)
+}
+
+func Setup(apiKey string, commit string, env string, packages []string) {
+	def.Setup(apiKey, commit, env, packages)
+}
+
+func Configured() bool {
+	return bugsnaggo.Config.APIKey != ""
+}

--- a/bugsnag/bugsnagdata_test.go
+++ b/bugsnag/bugsnagdata_test.go
@@ -1,0 +1,87 @@
+package bugsnag
+
+import (
+	bugsnaggo "github.com/bugsnag/bugsnag-go"
+)
+
+// bugsnagdata is the utility object which helps with writing bugsnag's unit tests
+type bugsnagdata struct {
+	dataList []interface{}
+}
+
+func newBugsnagData(rawData []interface{}) *bugsnagdata {
+	return &bugsnagdata{
+		dataList: rawData,
+	}
+}
+
+func (dl *bugsnagdata) getBugsnaggoErrorClass() string {
+	for _, data := range dl.dataList {
+		if errObj, ok := data.(bugsnaggo.ErrorClass); ok {
+			return errObj.Name
+		}
+	}
+	return ""
+}
+
+func (dl *bugsnagdata) hasErrTab() bool {
+	for _, data := range dl.dataList {
+		if myMap, ok := data.(bugsnaggo.MetaData); ok {
+			if v, ok := myMap["Error"]; ok {
+				if _, ok := v["details"]; ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (dl *bugsnagdata) getLogTab() Rows {
+	for _, data := range dl.dataList {
+		if myMap, ok := data.(bugsnaggo.MetaData); ok {
+			if t, ok := myMap["Log"]; ok {
+				return t
+			}
+		}
+	}
+	return nil
+}
+
+func (dl *bugsnagdata) getContext() string {
+	for _, data := range dl.dataList {
+		if cont, ok := data.(bugsnaggo.Context); ok {
+			return cont.String
+		}
+	}
+	return ""
+}
+
+func (dl *bugsnagdata) getUser() string {
+	for _, data := range dl.dataList {
+		if user, ok := data.(bugsnaggo.User); ok {
+			return user.Id
+		}
+	}
+	return ""
+}
+
+func (dl *bugsnagdata) getTab(label string) Rows {
+	for _, data := range dl.dataList {
+		if myMap, ok := data.(bugsnaggo.MetaData); ok {
+			if t, ok := myMap[label]; ok {
+				return t
+			}
+		}
+	}
+	return nil
+}
+
+func (dl *bugsnagdata) hasValue(data interface{}) bool {
+	for _, v := range dl.dataList {
+		if v == data {
+			return true
+		}
+	}
+	return false
+}

--- a/bugsnag/bugsnagger.go
+++ b/bugsnag/bugsnagger.go
@@ -1,0 +1,262 @@
+// Package bugsnag extends the functionalities of the APIs in the bugsnag-go library.
+package bugsnag
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strings"
+
+	bugsnaggo "github.com/bugsnag/bugsnag-go"
+	bugsnaggoErr "github.com/bugsnag/bugsnag-go/errors"
+	"github.com/bugsnag/panicwrap"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/http2"
+)
+
+// Rows is a helper type to make it easier to build bugsnag tab contents,
+// with simple Go literals as in `Tab{"Stuff",Rows{"a":1,"b":2,...}}`.
+type Rows map[string]interface{}
+
+// Tab can be used to attach an additional info tab to bugsnag error reports.
+// Just pass it to the Notify function.
+type Tab struct {
+	Label string
+	Rows  Rows
+}
+
+// notifier by default is linked to bugsnaggo.Notify. We swap it out for testing.
+type notifier func(err error, rawData ...interface{}) (e error)
+
+// Bugsnagger uses the default Notifier and Config object that bugsnag-go (3rd party lib) provides.
+// It formats the rawData to the general MetaData format for the bugsnag-go API.
+// Bugsnagger also contains the implementation for the external APIs that are defined in bugsnag.go.
+type bugsnagger struct {
+	config   *bugsnaggo.Configuration
+	notifier notifier
+}
+
+func NewBugsnagger(config *bugsnaggo.Configuration, notifier notifier) *bugsnagger {
+	return &bugsnagger{config: config, notifier: notifier}
+}
+
+// Optional metadata can be passed in as well, however only certain types of those will have an effect:
+// * string will be used to set the BS context (usually url path or goroutine identifier)
+// * http.Request creates Request tab in BS and tries to set context
+// * log.Entry/log.Fields creates Details tab reflecting the entry fields
+// * Tab allows creating arbitrary tab
+func (snagger *bugsnagger) buildData(err error, rawData ...interface{}) ([]interface{}, error) {
+	var (
+		user    bugsnaggo.User
+		req     *http.Request
+		context string
+		cause   error
+	)
+
+	bugsnagData := []interface{}{bugsnaggo.SeverityError}
+	md := make(bugsnaggo.MetaData)
+
+	if err != nil {
+		bugsnagData = append(bugsnagData, bugsnaggo.ErrorClass{Name: extractErrorClass(err)})
+		context, cause = snagger.formatError(err)
+		//set the Error tab with details/stacktrace
+		md["Error"] = Rows{"details": fmt.Sprintf("%+v", err)}
+	}
+
+	//extract more context/metadata from the rawData
+	for _, v := range rawData {
+		switch v := v.(type) {
+		case string:
+			context = v
+		case *http.Request:
+			req = v
+			bugsnagData = append(bugsnagData, req)
+		case *log.Entry:
+			userID, message, mdData := snagger.processLogEntry(v)
+			snagger.updateUserID(&user, userID)
+			if context == "" {
+				context = message
+			}
+			md["Log"] = mdData
+		case log.Fields:
+			userID := snagger.extractUserID(v)
+			snagger.updateUserID(&user, userID)
+			md["Log"] = v
+		case TabWriter:
+			tab := v.CreateBugsnagTab()
+			md[tab.Label] = tab.Rows
+		case Tab:
+			md[v.Label] = v.Rows
+		default:
+			bugsnagData = append(bugsnagData, v)
+		}
+	}
+
+	if len(md) > 0 {
+		bugsnagData = append(bugsnagData, md)
+	}
+	if user.Id != "" {
+		bugsnagData = append(bugsnagData, user)
+	}
+	if context == "" && req != nil && req.URL != nil {
+		context = req.URL.Path
+	}
+	bugsnagData = append(bugsnagData, bugsnaggo.Context{String: context})
+
+	return bugsnagData, cause
+}
+
+func (snagger *bugsnagger) formatError(err error) (string, error) {
+	var context string
+	cause := errors.Cause(err)
+	if uerr, ok := cause.(*url.Error); ok {
+		cause = uerr.Err
+	} else if serr, ok := cause.(*http2.StreamError); ok {
+		if serr.Cause != nil {
+			cause = serr.Cause
+		} else {
+			cause = fmt.Errorf("stream error: %s", serr.Code)
+		}
+	}
+
+	// Try to get the wrapped message to set the bugsnag context
+	errString := fmt.Sprintf("%s", err)
+	// Note that error.Wrap always appends a space after the :
+	i := strings.LastIndex(errString, ": ")
+	if i != -1 {
+		context = errString[0:i]
+	}
+	return context, cause
+}
+
+func (snagger *bugsnagger) processLogEntry(entry *log.Entry) (string, string, map[string]interface{}) {
+	fields := entry.Data
+	return snagger.extractUserID(fields), entry.Message, fields
+}
+
+func (snagger *bugsnagger) extractUserID(fields log.Fields) string {
+	var userId string
+	if s := fields["shopID"]; s != nil {
+		userId = fmt.Sprint(s)
+	}
+	return userId
+}
+
+func (snagger *bugsnagger) updateUserID(user *bugsnaggo.User, userId string) {
+	if len(userId) > 0 {
+		user.Id = userId
+	}
+}
+
+// Notify annotates bugsnag entries with metadata and then sends it to bugsnag
+func (snagger *bugsnagger) Notify(err error, rawData ...interface{}) {
+	if err == nil || snagger.config.APIKey == "" {
+		return
+	}
+
+	bugsnagData, cause := snagger.buildData(err, rawData...)
+	if err := snagger.notifier(cause, bugsnagData...); err != nil {
+		log.Warnf("bugsnag notifier error: %s\n", err)
+	}
+}
+
+// AutoNotify when deferred, records a panic to Bugsnag and exits the program
+func (snagger *bugsnagger) AutoNotify(rawData ...interface{}) {
+	if r := recover(); r != nil {
+		snagger.Notify(recoverError(r), rawData...)
+		log.Error(r)
+		debug.PrintStack()
+		os.Exit(1)
+	}
+}
+
+//AutoRecover when deferred, records a panic to Bugsnag and recovers.
+func (snagger *bugsnagger) AutoRecover(rawData ...interface{}) {
+	if r := recover(); r != nil {
+		snagger.Notify(recoverError(r), rawData...)
+		log.Error(r)
+	}
+}
+
+func recoverError(e interface{}) (err error) {
+	switch e := e.(type) {
+	case error:
+		err = e
+	default:
+		err = errors.Errorf("%v (%T)", e, e)
+	}
+	return
+}
+
+//augment the bugnsag http middleware to add POST body to the request tab
+func httpRequestMiddleware(event *bugsnaggo.Event, config *bugsnaggo.Configuration) error {
+	for _, datum := range event.RawData {
+		if request, ok := datum.(*http.Request); ok {
+			if err := request.ParseForm(); err != nil {
+				return err
+			}
+			event.MetaData.Update(bugsnaggo.MetaData{
+				"request": {
+					"form": request.Form,
+				},
+			})
+		}
+	}
+	return nil
+}
+
+func (snagger *bugsnagger) Setup(apiKey string, commit string, env string, packages []string) {
+	// Add the bugsnag package and it's folder location on disk to bugsnag's ProjectPackages.
+	// This will ensure that Notify calls from bugsnagger.go will always share the same file name
+	// and will retain grouping across Shopify/goose dependency upgrades.
+	packages = append(packages, "main*", "github.com/Shopify/goose/bugsnag")
+	if _, file, _, ok := runtime.Caller(0); ok {
+		gooseMod := strings.TrimSuffix(file, "bugsnag/bugsnagger.go")
+		packages = append(packages, gooseMod+"*")
+	}
+
+	bugsnaggo.OnBeforeNotify(httpRequestMiddleware)
+	bugsnaggo.Configure(bugsnaggo.Configuration{
+		APIKey:          apiKey,
+		AppVersion:      commit,
+		ProjectPackages: packages,
+		ReleaseStage:    env,
+		Synchronous:     true,
+		PanicHandler:    panicHandler,
+	})
+}
+
+// panicHandler uses panicwrap.BasicWrap instead of panicwrap.BasicMonitor to catch panics and notify.
+// The difference is that the parent process is now the one monitoring and so there is no race when the application
+// is containerized.
+func panicHandler() {
+	defer AutoNotify()
+
+	exitStatus, err := panicwrap.BasicWrap(func(output string) {
+		toNotify, err := bugsnaggoErr.ParsePanic(output)
+
+		if err != nil {
+			log.Errorf("bugsnag.handleUncaughtPanic: %v", err)
+		}
+		state := bugsnaggo.HandledState{bugsnaggo.SeverityReasonUnhandledPanic, bugsnaggo.SeverityError, true, ""}
+		Notify(toNotify, state, bugsnaggo.Configuration{Synchronous: true})
+	})
+	if err != nil {
+		// Something went wrong setting up the panic wrapper. Unlikely,
+		// but possible.
+		panic(err)
+	}
+
+	// If exitStatus >= 0, then we're the parent process and the panicwrap
+	// re-executed ourselves and completed. Just exit with the proper status.
+	if exitStatus >= 0 {
+		os.Exit(exitStatus)
+	}
+
+	// Otherwise, exitStatus < 0 means we're the child. Continue executing as
+	// normal...
+}

--- a/bugsnag/bugsnagger_test.go
+++ b/bugsnag/bugsnagger_test.go
@@ -24,7 +24,7 @@ func init() {
 	}
 
 	mConfig := &bugsnaggo.Configuration{APIKey: "key"}
-	mSnagger = NewBugsnagger(mConfig, mNotifier)
+	mSnagger = newBugsnagger(mConfig, mNotifier)
 }
 
 func TestSetup(t *testing.T) {
@@ -153,7 +153,7 @@ type customTab struct {
 
 func (ct *customTab) CreateBugsnagTab() Tab {
 	return Tab{
-		Label: "test",
+		Label: "custom",
 		Rows:  Rows{"key": ct.val},
 	}
 }
@@ -161,7 +161,7 @@ func (ct *customTab) CreateBugsnagTab() Tab {
 func TestBuildDataTabWriter(t *testing.T) {
 	dataList, err := mSnagger.buildData(errors.New("err"), &customTab{"val"})
 	require.Equal(t, "err", err.Error())
-	require.Equal(t, Rows{"key": "val"}, newBugsnagData(dataList).getTab("test"))
+	require.Equal(t, Rows{"key": "val"}, newBugsnagData(dataList).getTab("custom"))
 }
 
 func TestBuildDataRegularData(t *testing.T) {
@@ -192,7 +192,7 @@ func TestAutoRecover(t *testing.T) {
 	}
 
 	errConfig := &bugsnaggo.Configuration{APIKey: "errAPI"}
-	snagger := NewBugsnagger(errConfig, notifier)
+	snagger := newBugsnagger(errConfig, notifier)
 
 	go func() {
 		defer snagger.AutoRecover()

--- a/bugsnag/bugsnagger_test.go
+++ b/bugsnag/bugsnagger_test.go
@@ -1,0 +1,207 @@
+package bugsnag
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	bugsnaggo "github.com/bugsnag/bugsnag-go"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+)
+
+var (
+	mSnagger *bugsnagger
+)
+
+func init() {
+	mNotifier := func(err error, rawData ...interface{}) error {
+		panic("Notifier function is called")
+	}
+
+	mConfig := &bugsnaggo.Configuration{APIKey: "key"}
+	mSnagger = NewBugsnagger(mConfig, mNotifier)
+}
+
+func TestSetup(t *testing.T) {
+	var (
+		apiKey = "apiTest"
+		commit = "commitSHA"
+		env    = "envTest"
+		pack   = "packageTest"
+	)
+
+	Setup(apiKey, commit, env, []string{pack})
+	require.Equal(t, apiKey, bugsnaggo.Config.APIKey)
+	require.Equal(t, commit, bugsnaggo.Config.AppVersion)
+	require.Equal(t, env, bugsnaggo.Config.ReleaseStage)
+	require.Equal(t, pack, bugsnaggo.Config.ProjectPackages[0])
+	require.Equal(t, "main*", bugsnaggo.Config.ProjectPackages[1])
+	require.Equal(t, "github.com/Shopify/goose/bugsnag", bugsnaggo.Config.ProjectPackages[2])
+	require.True(t, strings.Contains(bugsnaggo.Config.ProjectPackages[3], "github.com/Shopify/goose/*"))
+	require.True(t, bugsnaggo.Config.Synchronous)
+}
+
+func TestNotify(t *testing.T) {
+	require.NotPanics(t, func() { mSnagger.Notify(nil) })
+	require.Panics(t, func() { mSnagger.Notify(errors.New("err")) })
+}
+
+func TestBuildDataError_cause(t *testing.T) {
+	dataList, err := mSnagger.buildData(errors.New("err"))
+	require.Equal(t, "err", err.Error())
+	require.Equal(t, "err", newBugsnagData(dataList).getBugsnaggoErrorClass())
+	require.True(t, newBugsnagData(dataList).hasErrTab())
+	require.Equal(t, "", newBugsnagData(dataList).getContext())
+}
+
+func TestBuildDataError_wrappedCause(t *testing.T) {
+	err := errors.Wrap(errors.Wrap(errors.New("err"), "msg1"), "msg2")
+	dataList, err := mSnagger.buildData(err)
+	require.Equal(t, "err", err.Error())
+	require.Equal(t, "err", newBugsnagData(dataList).getBugsnaggoErrorClass())
+	require.True(t, newBugsnagData(dataList).hasErrTab())
+	require.Equal(t, "msg2: msg1", newBugsnagData(dataList).getContext())
+}
+
+func TestBuildDataError_urlError(t *testing.T) {
+	// url error
+	err := errors.Wrap(&url.Error{Op: "GET", URL: "lol.com", Err: errors.New("err")}, "url fail")
+	dataList, err := mSnagger.buildData(err)
+	require.Equal(t, "err", err.Error())
+	require.Equal(t, "GET lol.com: err", newBugsnagData(dataList).getBugsnaggoErrorClass())
+	require.True(t, newBugsnagData(dataList).hasErrTab())
+	require.Equal(t, "url fail: GET lol.com", newBugsnagData(dataList).getContext())
+}
+
+func TestBuildDataError_http2Stream(t *testing.T) {
+	// http2 stream error with code
+	err := errors.Wrap(&http2.StreamError{Code: 1}, "http2 fail")
+	dataList, err := mSnagger.buildData(err)
+	require.Equal(t, "stream error: PROTOCOL_ERROR", err.Error())
+	require.Equal(t, "stream error: stream ID 0; PROTOCOL_ERROR", newBugsnagData(dataList).getBugsnaggoErrorClass())
+	require.True(t, newBugsnagData(dataList).hasErrTab())
+	require.Equal(t, "http2 fail: stream error", newBugsnagData(dataList).getContext())
+}
+
+func TestBuildDataString(t *testing.T) {
+	dataList, err := mSnagger.buildData(errors.New("err"), "database connection")
+	require.Equal(t, "err", err.Error())
+	require.True(t, newBugsnagData(dataList).hasErrTab())
+	require.Equal(t, "database connection", newBugsnagData(dataList).getContext())
+}
+
+func TestBuildDataHttpRequest(t *testing.T) {
+	req := &http.Request{
+		Method: "GET",
+		URL: &url.URL{
+			Path: "lol.com",
+		},
+	}
+	dataList, err := mSnagger.buildData(errors.New("err"), req)
+	require.Equal(t, "err", err.Error())
+	require.Equal(t, "lol.com", newBugsnagData(dataList).getContext())
+}
+
+func TestBuildDataLogEntry(t *testing.T) {
+	entry := log.NewEntry(&log.Logger{})
+	entry = entry.WithFields(log.Fields{
+		"key":    "val",
+		"shopID": 12345,
+	})
+	entry.Message = "should be ignored"
+	err := errors.Wrap(errors.New("inner error"), "err error")
+	dataList, err := mSnagger.buildData(err, entry)
+	require.Equal(t, "inner error", err.Error())
+	require.Equal(t, "inner error", newBugsnagData(dataList).getBugsnaggoErrorClass())
+	require.Equal(t, "err error", newBugsnagData(dataList).getContext())
+	require.Equal(t, Rows{"key": "val", "shopID": 12345}, newBugsnagData(dataList).getLogTab())
+	require.Equal(t, "12345", newBugsnagData(dataList).getUser())
+}
+
+func TestBuildDataLogFields(t *testing.T) {
+	dataList, err := mSnagger.buildData(errors.New("err"), log.Fields{
+		"key":    "val",
+		"shopID": 12345,
+	})
+	require.Equal(t, "err", err.Error())
+	require.Equal(t, "err", newBugsnagData(dataList).getBugsnaggoErrorClass())
+	require.Equal(t, "", newBugsnagData(dataList).getContext())
+	require.Equal(t, Rows{"key": "val", "shopID": 12345}, newBugsnagData(dataList).getLogTab())
+	require.Equal(t, "12345", newBugsnagData(dataList).getUser())
+}
+
+func TestBuildDataTab(t *testing.T) {
+	tab := Tab{
+		Label: "test",
+		Rows: map[string]interface{}{
+			"err": int(1),
+		},
+	}
+	dataList, err := mSnagger.buildData(errors.New("err"), tab)
+	require.Equal(t, "err", err.Error())
+	require.Equal(t, Rows{"err": 1}, newBugsnagData(dataList).getTab("test"))
+}
+
+type customTab struct {
+	val string
+}
+
+func (ct *customTab) CreateBugsnagTab() Tab {
+	return Tab{
+		Label: "test",
+		Rows:  Rows{"key": ct.val},
+	}
+}
+
+func TestBuildDataTabWriter(t *testing.T) {
+	dataList, err := mSnagger.buildData(errors.New("err"), &customTab{"val"})
+	require.Equal(t, "err", err.Error())
+	require.Equal(t, Rows{"key": "val"}, newBugsnagData(dataList).getTab("test"))
+}
+
+func TestBuildDataRegularData(t *testing.T) {
+	dataList, err := mSnagger.buildData(errors.New("err"), 100)
+	require.Equal(t, "err", err.Error())
+	require.True(t, newBugsnagData(dataList).hasValue(100))
+}
+
+func TestBuildDataCustomErrorClass(t *testing.T) {
+	cause := errors.New("err")
+	err := WithErrorClass(cause, "CUSTOM")
+	dataList, returnedCause := mSnagger.buildData(err)
+	require.Equal(t, cause, returnedCause)
+	require.Equal(t, "CUSTOM", newBugsnagData(dataList).getBugsnaggoErrorClass())
+}
+
+func TestAutoRecover(t *testing.T) {
+	done := make(chan interface{})
+	// when autoRecover is called inside a go-routine, we should no longer receive a panic
+	// in the main process.
+	notifier := func(err error, rawData ...interface{}) (e error) {
+		defer func() {
+			close(done)
+		}()
+		require.Equal(t, "oops (string)", err.Error())
+		require.True(t, newBugsnagData(rawData).hasErrTab())
+		return nil
+	}
+
+	errConfig := &bugsnaggo.Configuration{APIKey: "errAPI"}
+	snagger := NewBugsnagger(errConfig, notifier)
+
+	go func() {
+		defer snagger.AutoRecover()
+		panic("oops")
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("test timed out")
+	}
+}

--- a/bugsnag/doc.go
+++ b/bugsnag/doc.go
@@ -1,0 +1,52 @@
+/*
+Package bugsnag provides a simple wrapper over the bugsnag/bugsnag-go lib that maintains
+the same Notify(err, rawData...) API but with improved setup and error decoration.
+
+Usage
+
+The client should only need to use the static/package level APIs defined in bugsnag.go
+	func main(){
+		bugsnag.Setup("apiKey", "SHA", "env", []string{"github.com/Shopify/yourClientRepo"})
+		defer bugsnag.AutoNotify()
+
+		go func(){
+			defer bugsnag.AutoRecover()
+			panic("err")
+		}
+
+		i, err := somethingThatCanError()
+		bugsnag.Notify(err, rawData...)
+	}
+
+Features
+
+Smart handling of errors passed to notify populating the "Error" tab in bugsnag. If the error is wrapped using pkg/errors then its stacktrace
+and context messages are extracted correctly.
+
+The bugsnag.ErrorClass is set intelligently dealing with go.mod versions. You can also implement the errorClasser interface
+to override this using the bugsnag.WithErrorClass(err, class) and bugsnag.Wrapf(err, format, args...) helper methods.
+
+Better support for logrus.Fields, *logrus.Entry, *http.Request, *url.Error and *http2.StreamError objects.
+
+HTTP POST request body is extracted into the the Request tab in bugsnag.
+
+Project packages are handled correctly which helps with proper grouping of bugs in bugsnag.
+
+The default panic handler is fixed so that panics are not dropped in containerized environments.
+
+Create custom bugsnag tabs easily by implementing the TabWriter interface or Tab objects passed in as rawData. e.g.:
+	type customTab struct {
+		val string
+	}
+
+	func (ct *customTab) CreateBugsnagTab() Tab {
+		return Tab{
+			Label: "Custom Tab",
+			Rows:  Rows{"Key": ct.val},
+		}
+	}
+
+	bugsnag.Notify(err, &customTab{"value"})
+
+*/
+package bugsnag

--- a/bugsnag/with_class.go
+++ b/bugsnag/with_class.go
@@ -1,0 +1,89 @@
+package bugsnag
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// An interface errors can implement to better control how they are
+// grouped in Bugsnag.
+// https://docs.bugsnag.com/product/error-grouping/#top-in-project-stackframe
+type errorClasser interface {
+	ErrorClass() string
+}
+
+type withClass struct {
+	cause error
+	class string
+}
+
+func (w *withClass) Error() string {
+	return w.cause.Error()
+}
+
+func (w *withClass) Cause() error {
+	return w.cause
+}
+
+func (w *withClass) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, w.class)
+			io.WriteString(s, ": ")
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+func (w *withClass) ErrorClass() string {
+	return w.class
+}
+
+// WithErrorClass wraps the error with an error class used
+// to control the grouping in Bugsnag
+func WithErrorClass(err error, class string) error {
+	if err == nil {
+		return nil
+	}
+	return &withClass{
+		cause: err,
+		class: class,
+	}
+}
+
+// Wrapf acts like errors.Wrapf except it also sets the
+// error class to be equal to the message
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	message := fmt.Sprintf(format, args...)
+	return WithErrorClass(errors.Wrap(err, message), message)
+}
+
+func extractErrorClass(err error) string {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		if classer, ok := err.(errorClasser); ok {
+			return classer.ErrorClass()
+		}
+
+		if causer, ok := err.(causer); ok {
+			err = causer.Cause()
+		} else {
+			return err.Error()
+		}
+	}
+
+	return ""
+}

--- a/bugsnag/with_class_test.go
+++ b/bugsnag/with_class_test.go
@@ -1,0 +1,41 @@
+package bugsnag
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractWithoutErrorClass(t *testing.T) {
+	err := errors.New("test error")
+	require.Equal(t, "test error", extractErrorClass(err))
+}
+
+func TestWithErrorClass(t *testing.T) {
+	err := WithErrorClass(errors.New("test error"), "FOO")
+	require.Equal(t, "FOO", extractErrorClass(err))
+}
+
+func TestWrappedWithErrorClass(t *testing.T) {
+	err := errors.Wrapf(WithErrorClass(errors.New("test error"), "FOO"), "other %v", "bar")
+	require.Equal(t, "FOO", extractErrorClass(err))
+}
+
+func TestFormatErrorClass(t *testing.T) {
+	err := WithErrorClass(errors.New("test error"), "FOO")
+	formatted := fmt.Sprintf("%+v", err)
+	require.Contains(t, formatted, "FOO: test error")
+	require.Contains(t, formatted, "github.com/Shopify/goose/bugsnag.TestFormatErrorClass")
+	require.Contains(t, formatted, "github.com/Shopify/goose/bugsnag/with_class_test.go")
+	require.Contains(t, formatted, "testing.tRunner")
+	require.Contains(t, formatted, "src/testing/testing.go")
+	require.Contains(t, formatted, "runtime.goexit")
+	require.Contains(t, formatted, "src/runtime/asm_amd64.s")
+}
+
+func TestWrapf(t *testing.T) {
+	err := Wrapf(errors.New("test error"), "other %v %v", "bar", "baz")
+	require.Equal(t, "other bar baz", extractErrorClass(err))
+}

--- a/cond/cond_test.go
+++ b/cond/cond_test.go
@@ -389,11 +389,11 @@ func TestCond_Signal_random(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(1 * time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("test timeout")
 	}
 
-	assert.InDelta(t, threads/2, successes, float64(threads/4), "roughly half the threads should succeed")
+	assert.InDelta(t, threads, successes, float64(threads/2), "roughly half the threads should succeed")
 }
 
 func TestCondSignalStealing(t *testing.T) {

--- a/cond/cond_test.go
+++ b/cond/cond_test.go
@@ -389,11 +389,11 @@ func TestCond_Signal_random(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(2 * time.Second):
+	case <-time.After(1 * time.Second):
 		t.Fatal("test timeout")
 	}
 
-	assert.InDelta(t, threads, successes, float64(threads/2), "roughly half the threads should succeed")
+	assert.InDelta(t, threads, successes, float64(3*threads/4), "roughly a quarter of the threads should succeed")
 }
 
 func TestCondSignalStealing(t *testing.T) {


### PR DESCRIPTION
- This is a helper/wrapper lib that deals with a lot of quirks of
  the bugsnag api and the default bugsnag-go client. It better handles
  errors, panics, logs etc.
- It maintains the same api as the default go lib so this should be a drop in replacement.
- This is mostly a copy pasta from the similar reportify lib but cleaned
  up the code, tests and doc.

cc @Shopify/caching-queuing @Shopify/data-distribution 