### PR TITLE
Add response-logging capabilities to RequestMetricsMiddleware

### DIFF
--- a/srvutil/metrics.go
+++ b/srvutil/metrics.go
@@ -2,6 +2,7 @@ package srvutil
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"net"
 	"net/http"
@@ -14,14 +15,24 @@ import (
 	"github.com/Shopify/goose/statsd"
 )
 
+type BodyLogPredicateFunc func(statusCode int) bool
+
+func LogErrorBody(statusCode int) bool {
+	return statusCode >= 400
+}
+
 type loggableHTTPRecorder interface {
 	http.ResponseWriter
 	LogFields() logrus.Fields
+	ResponseBody() *string
 }
 
 type httpRecorder struct {
 	http.ResponseWriter
 	statusCode int
+
+	bodyLogPredicate BodyLogPredicateFunc
+	body             bytes.Buffer
 }
 
 func (w *httpRecorder) WriteHeader(statusCode int) {
@@ -34,6 +45,11 @@ func (w *httpRecorder) Write(data []byte) (int, error) {
 	if w.statusCode == 0 {
 		w.statusCode = http.StatusOK
 	}
+
+	if w.bodyLogPredicate != nil && w.bodyLogPredicate(w.statusCode) {
+		w.body.Write(data)
+	}
+
 	return w.ResponseWriter.Write(data)
 }
 
@@ -47,6 +63,14 @@ func (w *httpRecorder) LogFields() logrus.Fields {
 	return nil
 }
 
+func (w *httpRecorder) ResponseBody() *string {
+	if w.body.Len() == 0 {
+		return nil
+	}
+	s := w.body.String()
+	return &s
+}
+
 type hijackableRecorder struct {
 	httpRecorder
 }
@@ -56,41 +80,50 @@ func (w *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return w.httpRecorder.ResponseWriter.(http.Hijacker).Hijack()
 }
 
-func newHTTPRecorder(w http.ResponseWriter) loggableHTTPRecorder {
-	recorder := httpRecorder{ResponseWriter: w}
+func newHTTPRecorder(w http.ResponseWriter, bodyLogPredicate BodyLogPredicateFunc) loggableHTTPRecorder {
+	recorder := httpRecorder{ResponseWriter: w, bodyLogPredicate: bodyLogPredicate}
 	if _, ok := w.(http.Hijacker); ok {
 		return &hijackableRecorder{recorder}
 	}
 	return &recorder
 }
 
-// RequestMetricsMiddleware records the time taken to serve a request.
+// RequestMetricsMiddleware records the time taken to serve a request, and logs request and response data.
 // Example tags: statusClass:2xx, statusCode:200
 // Should be added as a middleware after RequestContextMiddleware to benefit from its tags
-func RequestMetricsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+func RequestMetricsMiddleware(bodyLogPredicate BodyLogPredicateFunc) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
 
-		recorder := newHTTPRecorder(w)
-		ctx = statsd.WatchingTagLoggable(ctx, recorder)
-		r = r.WithContext(ctx)
+			recorder := newHTTPRecorder(w, bodyLogPredicate)
+			ctx = statsd.WatchingTagLoggable(ctx, recorder)
+			r = r.WithContext(ctx)
 
-		reqHeaders := redact.Headers(r.Header)
+			reqHeaders := redact.Headers(r.Header)
 
-		log(ctx, nil).
-			WithField("method", r.Method).
-			WithField("headers", reqHeaders).
-			Info("http request")
+			log(ctx).
+				WithField("method", r.Method).
+				WithField("headers", reqHeaders).
+				Info("http request")
 
-		metrics.HTTPRequest.Time(ctx, func() error {
-			next.ServeHTTP(recorder, r)
-			return nil
+			metrics.HTTPRequest.Time(ctx, func() error {
+				next.ServeHTTP(recorder, r)
+				return nil
+			})
+
+			resHeaders := redact.Headers(w.Header())
+
+			logger := log(ctx).
+				WithField("headers", resHeaders)
+
+			if body := recorder.ResponseBody(); body != nil {
+				logger = logger.WithField("responseBody", *body)
+			}
+
+			logger.Info("http response")
+
 		})
+	}
 
-		resHeaders := redact.Headers(w.Header())
-
-		log(ctx, nil).
-			WithField("headers", resHeaders).
-			Info("http response")
-	})
 }

--- a/srvutil/metrics_test.go
+++ b/srvutil/metrics_test.go
@@ -48,7 +48,11 @@ func TestRequestMetricsMiddleware(t *testing.T) {
 		fmt.Fprintf(res, "hello %s", name)
 	})
 
-	sl = UseServlet(sl, RequestContextMiddleware, RequestMetricsMiddleware(LogErrorBody))
+	sl = UseServlet(
+		sl,
+		RequestContextMiddleware,
+		NewRequestMetricsMiddleware(&RequestMetricsMiddlewareConfig{BodyLogPredicate: LogErrorBody}),
+	)
 
 	s := NewServer(tb, "127.0.0.1:0", sl)
 	defer s.Tomb().Kill(nil)

--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -20,15 +20,15 @@ import (
 
 func ExampleNewServer() {
 	tb := &tomb.Tomb{}
-	sl := FuncServlet("/hello/{name}", func(res http.ResponseWriter, req *http.Request) {
-		name := mux.Vars(req)["name"]
-		fmt.Fprintf(res, "hello %s", name)
+	sl := FuncServlet("/hello/{name}", func(w http.ResponseWriter, r *http.Request) {
+		name := mux.Vars(r)["name"]
+		fmt.Fprintf(w, "hello %s", name)
 	})
 
 	sl = UseServlet(sl,
 		// Should be first to properly add tags and logging fields to the context
 		RequestContextMiddleware,
-		RequestMetricsMiddleware,
+		RequestMetricsMiddleware(LogErrorBody),
 		safely.Middleware,
 	)
 

--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -28,7 +28,7 @@ func ExampleNewServer() {
 	sl = UseServlet(sl,
 		// Should be first to properly add tags and logging fields to the context
 		RequestContextMiddleware,
-		RequestMetricsMiddleware(LogErrorBody),
+		NewRequestMetricsMiddleware(&RequestMetricsMiddlewareConfig{BodyLogPredicate: LogErrorBody}),
 		safely.Middleware,
 	)
 


### PR DESCRIPTION
Since the `http.ResponseWriter` is an interface that doesn't give you access to any of the data written (except headers), we already have our own recorder passthrough version, which records the response status code, to include in statsd metrics and logs.

This PR changes `RequestMetricsMiddleware` so that it can be configured to also log response bodies. Usually this isn't something you want - response bodies can be really large, or they can contain sensitive data. However, in API services, responses with status code 4xx or 5xx are often small, and contain nothing sensitive, and it can be really useful for debugging to log the response body. Sometimes it can be easier to debug why clients are getting a 4xx by looking at server logs than by whatever error handling the client has.

I'm specifically trying to solve the issue where our go service is using https://github.com/99designs/gqlgen, and clients send GraphQL requests that don't conform to the schema. Currently in gqlgen, those 422 error responses are unloggable. If this PR merges, I can close https://github.com/99designs/gqlgen/pull/742 - that PR is starting to look less and less desirable to me.

This PR is a breaking change. Clients that use RequestMetricsMiddleware will need to update it to either pass in `nil` or `LogErrorBody` (or some custom function).