### PR TITLE
Expose logger.GetLoggableValues() publicly

### DIFF
--- a/logger/loggable.go
+++ b/logger/loggable.go
@@ -30,7 +30,7 @@ type keyValueContext struct {
 
 func (c *keyValueContext) Value(key interface{}) interface{} {
 	if key == logFieldsKey {
-		prev := getLoggableValues(c.Context)
+		prev := GetLoggableValues(c.Context)
 		prev[c.key] = c.value
 		return prev
 	}
@@ -44,7 +44,7 @@ type loggableContext struct {
 
 func (c *loggableContext) Value(key interface{}) interface{} {
 	if key == logFieldsKey {
-		prev := getLoggableValues(c.Context)
+		prev := GetLoggableValues(c.Context)
 		for k, v := range c.loggable.LogFields() {
 			prev[k] = v
 		}
@@ -82,14 +82,14 @@ func WatchingLoggable(ctx context.Context, l Loggable) context.Context {
 
 // GetLoggableValue returns the value of the metadata currently attached to the Context.
 func GetLoggableValue(ctx Valuer, key string) interface{} {
-	fields := getLoggableValues(ctx)
+	fields := GetLoggableValues(ctx)
 	if v, ok := fields[key]; ok {
 		return v
 	}
 	return nil
 }
 
-func getLoggableValues(ctx Valuer) logrus.Fields {
+func GetLoggableValues(ctx Valuer) logrus.Fields {
 	if ctx != nil {
 		fields, _ := ctx.Value(logFieldsKey).(logrus.Fields)
 		if fields != nil {

--- a/logger/loggable_test.go
+++ b/logger/loggable_test.go
@@ -209,3 +209,20 @@ func checkData(ctx context.Context, t *testing.T, expected logrus.Fields) {
 	expected["component"] = "testing" // Will always be there
 	assert.Equal(t, expected, New("testing")(ctx, nil).Data)
 }
+
+func TestGetLoggableValue(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithField(ctx, "foo", "bar")
+
+	value := GetLoggableValue(ctx, "foo")
+	assert.Equal(t, "bar", value)
+}
+
+func TestGetLoggableValues(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithField(ctx, "foo", "bar")
+	ctx = WithField(ctx, "poipoi", true)
+
+	values := GetLoggableValues(ctx)
+	assert.Equal(t, logrus.Fields{"foo": "bar", "poipoi": true}, values)
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -32,7 +32,7 @@ func ContextLog(ctx Valuer, err []error, entry *logrus.Entry) *logrus.Entry {
 	entry = entry.WithFields(GlobalFields)
 
 	if ctx != nil {
-		entry = entry.WithFields(getLoggableValues(ctx))
+		entry = entry.WithFields(GetLoggableValues(ctx))
 		if ctx, ok := ctx.(context.Context); ok {
 			entry = entry.WithContext(ctx)
 		}


### PR DESCRIPTION
### Context

Our service is using the log-values-in-go-context of the `logger` package. 
And we were using the Bugsnag integration from the `logrusbugsnag` package, and now we want to change this integration for an explicit call to report an error.

This is why we need to extract the logging context accumulated in the Go `Context` object.

### Changes

- Make the existing `getLoggableValues()` function public