### PR TITLE
Wait for Server shutdown before exiting Run loop

### DIFF
--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -186,6 +187,15 @@ func TestStoppableKeepaliveListener_Accept(t *testing.T) {
 
 		// Wait for the server to be ask to shutdown
 		<-tb.Dying()
+
+		// Allow time for the server to be trying to exit
+		time.Sleep(500 * time.Millisecond)
+
+		select {
+		case <-tb.Dead():
+			t.Fatal("should not be dead already")
+		default:
+		}
 
 		res.WriteHeader(http.StatusOK)
 		_, err := res.Write([]byte("great success"))


### PR DESCRIPTION
Per documentation:
> When Shutdown is called, Serve, ListenAndServe, and
> ListenAndServeTLS immediately return ErrServerClosed. Make sure the
> program doesn't exit and waits instead for Shutdown to return.

The test was no catching this issue because it was running too fast, so
I added a buffer.

This introduces a breaking change where the srvutil.Server no longer
embeds http.Server directly, but hides it behind a private property,
preventing someone from calling Shutdown, or any other method, manually.