### PR TITLE
Remove support to hardcode tags on metrics

### DIFF
--- a/statsd/counter.go
+++ b/statsd/counter.go
@@ -11,19 +11,19 @@ type Counter Collector
 //
 // The last parameter is an arbitrary array of tags as maps.
 func (c *Counter) Count(ctx context.Context, n int64, ts ...Tags) {
-	tags := loadTags(ctx, c.Tags, ts...)
+	tags := getStatsTags(ctx, ts...)
 	Count(ctx, c.Name, n, tags, c.Rate.Rate())
 }
 
 // Incr is basically the same as Count(1)
 func (c *Counter) Incr(ctx context.Context, ts ...Tags) {
-	tags := loadTags(ctx, c.Tags, ts...)
+	tags := getStatsTags(ctx, ts...)
 	Incr(ctx, c.Name, tags, c.Rate.Rate())
 }
 
 // Decr is basically the same as Count(-1)
 func (c *Counter) Decr(ctx context.Context, ts ...Tags) {
-	tags := loadTags(ctx, c.Tags, ts...)
+	tags := getStatsTags(ctx, ts...)
 	Decr(ctx, c.Name, tags, c.Rate.Rate())
 }
 

--- a/statsd/gaugor.go
+++ b/statsd/gaugor.go
@@ -10,6 +10,6 @@ type Gaugor Collector
 //
 // The last parameter is an arbitrary array of tags as maps.
 func (g *Gaugor) Gauge(ctx context.Context, n float64, ts ...Tags) {
-	tags := loadTags(ctx, g.Tags, ts...)
+	tags := getStatsTags(ctx, ts...)
 	Gauge(ctx, g.Name, n, tags, g.Rate.Rate())
 }

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -12,7 +12,6 @@ import (
 type Collector struct {
 	Name string
 	Rate sampleRate // 0 (default value) is interpreted as 100% (1.0)
-	Tags Tags
 }
 
 type sampleRate float64
@@ -22,13 +21,6 @@ func (s sampleRate) Rate() float64 {
 		return 1.0
 	}
 	return float64(s)
-}
-
-func loadTags(ctx context.Context, inheritTags Tags, extraTags ...Tags) []string {
-	if inheritTags != nil {
-		extraTags = append([]Tags{inheritTags}, extraTags...)
-	}
-	return getStatsTags(ctx, extraTags...)
 }
 
 // DefaultRate describes the sample rate used for submitting metrics to StatsD.

--- a/statsd/set_counter.go
+++ b/statsd/set_counter.go
@@ -10,6 +10,6 @@ type SetCounter Collector
 //
 // The last parameter is an arbitrary array of tags as maps.
 func (c *SetCounter) CountUnique(ctx context.Context, value string, ts ...Tags) {
-	tags := loadTags(ctx, c.Tags, ts...)
+	tags := getStatsTags(ctx, ts...)
 	Set(ctx, c.Name, value, tags, c.Rate.Rate())
 }

--- a/statsd/timer.go
+++ b/statsd/timer.go
@@ -15,7 +15,7 @@ type Timer Collector
 //
 // The last parameter is an arbitrary array of tags as maps.
 func (t *Timer) Duration(ctx context.Context, n time.Duration, ts ...Tags) {
-	tags := loadTags(ctx, t.Tags, ts...)
+	tags := getStatsTags(ctx, ts...)
 	Distribution(ctx, t.Name, n.Seconds()*1000, tags, t.Rate.Rate())
 }
 
@@ -46,12 +46,11 @@ type timerFinisher struct {
 }
 
 func (t *timerFinisher) Finish() {
-	tags := append([]Tags{t.timer.Tags}, t.tags...)
-	t.timer.Duration(t.ctx, time.Since(t.startTime), tags...)
+	t.timer.Duration(t.ctx, time.Since(t.startTime), t.tags...)
 }
 
 func (t *timerFinisher) SuccessFinish(errp *error) {
-	tags := append([]Tags{t.timer.Tags}, t.tags...)
+	tags := append([]Tags{}, t.tags...) // Copy the slice
 	if errp != nil {
 		tags = append(tags, Tags{"success": *errp == nil})
 	}


### PR DESCRIPTION
Hardcoding tags on the metric itself never proved to be useful and is adding a bunch of unnecessary complexity to the code, so remove it.