### PR TITLE
Remove Incr and Decr from the Backend since they are simply +/- 1

### DIFF
--- a/statsd/counter.go
+++ b/statsd/counter.go
@@ -17,14 +17,12 @@ func (c *Counter) Count(ctx context.Context, n int64, ts ...Tags) {
 
 // Incr is basically the same as Count(1)
 func (c *Counter) Incr(ctx context.Context, ts ...Tags) {
-	tags := getStatsTags(ctx, ts...)
-	Incr(ctx, c.Name, tags, c.Rate.Rate())
+	c.Count(ctx, 1, ts...)
 }
 
 // Decr is basically the same as Count(-1)
 func (c *Counter) Decr(ctx context.Context, ts ...Tags) {
-	tags := getStatsTags(ctx, ts...)
-	Decr(ctx, c.Name, tags, c.Rate.Rate())
+	c.Count(ctx, -1, ts...)
 }
 
 // SuccessCount is the same as calling Count but adds a `success` tag.

--- a/statsd/datadog_backend.go
+++ b/statsd/datadog_backend.go
@@ -46,14 +46,6 @@ func (b *datadogBackend) Distribution(ctx context.Context, name string, value fl
 	return b.client.Distribution(name, value, tags, rate)
 }
 
-func (b *datadogBackend) Decr(ctx context.Context, name string, tags []string, rate float64) error {
-	return b.client.Decr(name, tags, rate)
-}
-
-func (b *datadogBackend) Incr(ctx context.Context, name string, tags []string, rate float64) error {
-	return b.client.Incr(name, tags, rate)
-}
-
 func (b *datadogBackend) Set(ctx context.Context, name string, value string, tags []string, rate float64) error {
 	return b.client.Set(name, value, tags, rate)
 }

--- a/statsd/forwarding_backend.go
+++ b/statsd/forwarding_backend.go
@@ -34,14 +34,6 @@ func (b *forwardingBackend) Distribution(ctx context.Context, name string, value
 	return b.handler(ctx, "distribution", name, value, tags, rate)
 }
 
-func (b *forwardingBackend) Decr(ctx context.Context, name string, tags []string, rate float64) error {
-	return b.handler(ctx, "decr", name, nil, tags, rate)
-}
-
-func (b *forwardingBackend) Incr(ctx context.Context, name string, tags []string, rate float64) error {
-	return b.handler(ctx, "incr", name, nil, tags, rate)
-}
-
 func (b *forwardingBackend) Set(ctx context.Context, name string, value string, tags []string, rate float64) error {
 	return b.handler(ctx, "set", name, value, tags, rate)
 }

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -65,16 +65,6 @@ func (m Metric) Count(value int64) {
 	Count(context.Background(), m.name, value, m.tags, m.rate)
 }
 
-// Incr increments a counter based on the metric's name, tags, and rate by 1.
-func (m Metric) Incr() {
-	Incr(context.Background(), m.name, m.tags, m.rate)
-}
-
-// Decr decrements a counter based on the metric's name, tags, and rate by 1.
-func (m Metric) Decr() {
-	Decr(context.Background(), m.name, m.tags, m.rate)
-}
-
 // Distribution tracks the distribution of a set of values based on the metric's name, tags, and rate.
 func (m Metric) Distribution(value float64) {
 	Distribution(context.Background(), m.name, value, m.tags, m.rate)

--- a/statsd/metrics_test.go
+++ b/statsd/metrics_test.go
@@ -37,28 +37,6 @@ func TestCount(t *testing.T) {
 	backend.AssertCalled(t, "Count", context.Background(), "some_cmd", int64(100), []string{"tags"}, DefaultRate)
 }
 
-func TestIncr(t *testing.T) {
-	m := New("some_cmd", DefaultRate, "tags")
-
-	backend := new(mocks.Backend)
-	backend.On("Incr", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	SetBackend(backend)
-
-	m.Incr()
-	backend.AssertCalled(t, "Incr", context.Background(), "some_cmd", []string{"tags"}, DefaultRate)
-}
-
-func TestDecr(t *testing.T) {
-	m := New("some_ctr", 0.3, "t1", "t2")
-
-	backend := new(mocks.Backend)
-	backend.On("Decr", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	SetBackend(backend)
-
-	m.Decr()
-	backend.AssertCalled(t, "Decr", context.Background(), "some_ctr", []string{"t1", "t2"}, 0.3)
-}
-
 func TestDistribution(t *testing.T) {
 	m := New("thing", 0.3, "t1", "t2")
 

--- a/statsd/mocks/Backend.go
+++ b/statsd/mocks/Backend.go
@@ -26,20 +26,6 @@ func (_m *Backend) Count(ctx context.Context, name string, value int64, tags []s
 	return r0
 }
 
-// Decr provides a mock function with given fields: ctx, name, tags, rate
-func (_m *Backend) Decr(ctx context.Context, name string, tags []string, rate float64) error {
-	ret := _m.Called(ctx, name, tags, rate)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, []string, float64) error); ok {
-		r0 = rf(ctx, name, tags, rate)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Distribution provides a mock function with given fields: ctx, name, value, tags, rate
 func (_m *Backend) Distribution(ctx context.Context, name string, value float64, tags []string, rate float64) error {
 	ret := _m.Called(ctx, name, value, tags, rate)
@@ -75,20 +61,6 @@ func (_m *Backend) Histogram(ctx context.Context, name string, value float64, ta
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, float64, []string, float64) error); ok {
 		r0 = rf(ctx, name, value, tags, rate)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// Incr provides a mock function with given fields: ctx, name, tags, rate
-func (_m *Backend) Incr(ctx context.Context, name string, tags []string, rate float64) error {
-	ret := _m.Called(ctx, name, tags, rate)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, []string, float64) error); ok {
-		r0 = rf(ctx, name, tags, rate)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -30,10 +30,6 @@ type Backend interface {
 	Histogram(ctx context.Context, name string, value float64, tags []string, rate float64) error
 	// Distribution tracks the statistical distribution of a set of values across your infrastructure.
 	Distribution(ctx context.Context, name string, value float64, tags []string, rate float64) error
-	// Decr is just Count of -1
-	Decr(ctx context.Context, name string, tags []string, rate float64) error
-	// Incr is just Count of 1
-	Incr(ctx context.Context, name string, tags []string, rate float64) error
 	// Set counts the number of unique elements in a group.
 	Set(ctx context.Context, name string, value string, tags []string, rate float64) error
 	// Timing sends timing information, it is an alias for TimeInMilliseconds
@@ -86,16 +82,6 @@ func Histogram(ctx context.Context, name string, value float64, tags []string, r
 // Distribution tracks the statistical distribution of a set of values across your infrastructure.
 func Distribution(ctx context.Context, name string, value float64, tags []string, rate float64) {
 	warnIfError(ctx, currentBackend.Distribution(ctx, name, value, tags, rate))
-}
-
-// Decr is just Count of -1
-func Decr(ctx context.Context, name string, tags []string, rate float64) {
-	warnIfError(ctx, currentBackend.Decr(ctx, name, tags, rate))
-}
-
-// Incr is just Count of 1
-func Incr(ctx context.Context, name string, tags []string, rate float64) {
-	warnIfError(ctx, currentBackend.Incr(ctx, name, tags, rate))
 }
 
 // Set counts the number of unique elements in a group.


### PR DESCRIPTION
Simplifies the code.

They are still available on the metric as a convenience.