### PR TITLE
Disable Go tip CI because of a regression in the http error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - "1.13"
-  - tip
+#  - tip
 
 go_import_path: github.com/Shopify/goose
 


### PR DESCRIPTION
Errors like:
```
Get http://127.0.0.1:41627: dial tcp 127.0.0.1:41627: connect: connection refused
```

Are now:
```
Get "http://127.0.0.1:41627": dial tcp 127.0.0.1:41627: connect: connection refused
```

Example: https://travis-ci.org/Shopify/goose/jobs/649205598

Since this is not compatible, disable the tip testing for now.