### PR TITLE
Bump golangci

### DIFF
--- a/bin/style
+++ b/bin/style
@@ -8,7 +8,7 @@ class Style
   class << self
     INSTALLER_URL = 'https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh'
     EXECUTABLE = 'golangci-lint'
-    VERSION = '1.23.6'
+    VERSION = '1.23.8'
     VERSION_TAG = "v#{VERSION}"
 
     def call


### PR DESCRIPTION
Fixes:
```
bin/style
Installing golangci-lint...
golangci/golangci-lint info checking GitHub for tag 'v1.23.6'
golangci/golangci-lint crit unable to find 'v1.23.6' - use 'latest' or see https://github.com/golangci/golangci-lint/releases for details
```