### PR TITLE
Add support for multiple paths in GOPATH

### DIFF
--- a/bin/style
+++ b/bin/style
@@ -19,7 +19,8 @@ class Style
     private
 
     def install_path
-      File.join(ENV.fetch('GOPATH', ENV.fetch('HOME')), 'bin')
+      gopath = ENV.fetch('GOPATH', ENV.fetch('HOME')).split(':').first
+      File.join(gopath, 'bin')
     end
 
     def bin_path


### PR DESCRIPTION
Fixes this issue if `GOPATH` has multiple folders:
```
$ bin/style
Installing golangci-lint...
golangci/golangci-lint info checking GitHub for tag 'v1.23.8'
golangci/golangci-lint info found version: 1.23.8 for v1.23.8/darwin/amd64
install: mkdir /Users/seb:: Permission denied
Traceback (most recent call last):
	9: from bin/style:61:in `<main>'
	8: from bin/style:15:in `call'
	7: from bin/style:43:in `install'
	6: from /nix/store/p3igk9yljizscfvwxvn642xsrmd4v9km-ruby-2.6.5/lib/ruby/2.6.0/open-uri.rb:35:in `open'
	5: from /nix/store/p3igk9yljizscfvwxvn642xsrmd4v9km-ruby-2.6.5/lib/ruby/2.6.0/open-uri.rb:736:in `open'
	4: from /nix/store/p3igk9yljizscfvwxvn642xsrmd4v9km-ruby-2.6.5/lib/ruby/2.6.0/open-uri.rb:169:in `open_uri'
	3: from bin/style:44:in `block in install'
	2: from /nix/store/p3igk9yljizscfvwxvn642xsrmd4v9km-ruby-2.6.5/lib/ruby/2.6.0/open3.rb:159:in `popen2'
	1: from /nix/store/p3igk9yljizscfvwxvn642xsrmd4v9km-ruby-2.6.5/lib/ruby/2.6.0/open3.rb:219:in `popen_run'
bin/style:49:in `block (2 levels) in install': failed to install golangci-lint v1.23.8 (RuntimeError)
```