### PR TITLE
Do not add the gorilla mux variable as tag fields

### DIFF
--- a/srvutil/metrics_test.go
+++ b/srvutil/metrics_test.go
@@ -75,7 +75,7 @@ func TestRequestMetricsMiddleware(t *testing.T) {
 	assert.Equal(t, "hello world", string(body))
 
 	assert.NotNil(t, recordedTags, "should have recorded a %s tag", metrics.HTTPRequest.Name)
-	assert.Equal(t, []string{"route:/hello/@name", "route_name:world", "statusClass:2xx", "statusCode:200", "success:true"}, recordedTags)
+	assert.Equal(t, []string{"route:/hello/@name", "statusClass:2xx", "statusCode:200", "success:true"}, recordedTags)
 
 	output := strings.ToLower(logging.String())
 	assert.Contains(t, output, "statusclass=2xx")

--- a/srvutil/request.go
+++ b/srvutil/request.go
@@ -41,13 +41,6 @@ func buildRouteContext(r *http.Request) context.Context {
 		return ctx
 	}
 
-	vars := mux.Vars(r)
-	fields := logrus.Fields{}
-
-	for k, v := range vars {
-		fields[fmt.Sprintf("%s_%s", RouteKey, k)] = v
-	}
-
 	tpl, err := route.GetPathTemplate()
 	if err != nil {
 		log(ctx, err).Error("unable to get the route's template")
@@ -60,8 +53,21 @@ func buildRouteContext(r *http.Request) context.Context {
 		return ctx
 	}
 
-	fields[RouteKey] = tpl
-	return statsd.WithTagLogFields(ctx, fields)
+	// Adds the route as log field and tag.
+	ctx = statsd.WithTag(ctx, RouteKey, tpl)
+	ctx = logger.WithField(ctx, RouteKey, tpl)
+
+	// Adds the mux variables as log fields only, but not tags.
+	vars := mux.Vars(r)
+	fields := logrus.Fields{}
+
+	for k, v := range vars {
+		fields[fmt.Sprintf("%s_%s", RouteKey, k)] = v
+	}
+
+	ctx = logger.WithFields(ctx, fields)
+
+	return ctx
 }
 
 func BuildContext(r *http.Request) (context.Context, string) {

--- a/srvutil/request.go
+++ b/srvutil/request.go
@@ -55,16 +55,12 @@ func buildRouteContext(r *http.Request) context.Context {
 
 	// Adds the route as log field and tag.
 	ctx = statsd.WithTag(ctx, RouteKey, tpl)
-	ctx = logger.WithField(ctx, RouteKey, tpl)
 
 	// Adds the mux variables as log fields only, but not tags.
-	vars := mux.Vars(r)
-	fields := logrus.Fields{}
-
-	for k, v := range vars {
+	fields := logrus.Fields{RouteKey: tpl}
+	for k, v := range mux.Vars(r) {
 		fields[fmt.Sprintf("%s_%s", RouteKey, k)] = v
 	}
-
 	ctx = logger.WithFields(ctx, fields)
 
 	return ctx


### PR DESCRIPTION
`RequestContextMiddleware` adds all Gorilla mux variable (`github.com/gorilla/mux.Vars`) as tag fields in the Go Context.

This will often lead to metrics with way too many tags.

Note: the mux variables are still present as log fields.