### PR TITLE
Add dependencies to genmain shutdown

### DIFF
--- a/genmain/component.go
+++ b/genmain/component.go
@@ -1,0 +1,29 @@
+package genmain
+
+import "github.com/Shopify/goose/safely"
+
+// Component is used to represent various "components". At a high level, main()
+// essentially cobbles together a few components whose lifecycles are managed
+// by Tombs. `Component` allows us to treat them as black boxes.
+type Component interface {
+	safely.Runnable
+}
+
+type ComponentWithDependencies interface {
+	Component
+
+	Dependencies() []Component
+}
+
+func NewComponentWithDependencies(c Component, dependencies ...Component) ComponentWithDependencies {
+	return &dependencyWrapper{c, dependencies}
+}
+
+type dependencyWrapper struct {
+	Component
+	dependencies []Component
+}
+
+func (w *dependencyWrapper) Dependencies() []Component {
+	return w.dependencies
+}


### PR DESCRIPTION
Add support to wait for dependencies to shutdown before attempting to shutdown a parent component.

This is useful, for example, when you don't want to shutdown an event emitter or a database before allowing the web server to completely shutdown. 

- This does _not_ add dependency management for the _start_ of the components.
- Components are still being shutdown in parallel, but only if all their dependencies are properly dead.
- It is fully backwards compatible, if a component does not declare dependencies, it will be shut down at the beginning of the process.

Caveat: The metric about shutdown time now includes waiting for the component's dependencies to shutdown.