### PR TITLE
Add wrapper to create random sources

### DIFF
--- a/random/doc.go
+++ b/random/doc.go
@@ -1,0 +1,11 @@
+package random
+
+// For production use:
+// Standard: Seeded with the current time in nanoseconds.
+// Locked: Wrapped in a mutex to protect concurrent access.
+//
+// For tests:
+// Dummy: Random, but deterministic output, same as Seeded(0).
+// Mock: Mocked, needing to be configured before using.
+// Seeded: Random, but deterministic output.
+// Static: Always the same output.

--- a/random/doc.go
+++ b/random/doc.go
@@ -1,3 +1,4 @@
+// Package random provides an interface on top of math/rand to ease testing.
 package random
 
 // For production use:

--- a/random/dummy.go
+++ b/random/dummy.go
@@ -1,0 +1,13 @@
+package random
+
+import "math/rand"
+
+// NewDummy returns a rand.Rand seeded with 0.
+func NewDummy() *rand.Rand {
+	return rand.New(NewDummySource())
+}
+
+// NewDummySource returns a rand.Source seeded with 0.
+func NewDummySource() rand.Source {
+	return rand.NewSource(0)
+}

--- a/random/dummy_test.go
+++ b/random/dummy_test.go
@@ -1,0 +1,14 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDummy(t *testing.T) {
+	s := NewDummy()
+	// Predictable output
+	require.Equal(t, uint64(0x78fc2ffac2fd9401), s.Uint64())
+	require.Equal(t, uint64(0x1f5b0412ffd341c0), s.Uint64())
+}

--- a/random/locked.go
+++ b/random/locked.go
@@ -10,7 +10,7 @@ func NewLocked() *rand.Rand {
 	return rand.New(NewLockedSource(NewSource()))
 }
 
-// NewLockedSource wraps the with a mutex. To be used for concurrent access.
+// NewLockedSource wraps the Source with a mutex. To be used for concurrent access.
 func NewLockedSource(src rand.Source) rand.Source {
 	return &lockedSource{src: src}
 }

--- a/random/locked.go
+++ b/random/locked.go
@@ -1,0 +1,35 @@
+package random
+
+import (
+	"math/rand"
+	"sync"
+)
+
+// NewLocked returns a rand.Rand with a random source protected by a mutex. To be used for concurrent access.
+func NewLocked() *rand.Rand {
+	return rand.New(NewLockedSource(NewSource()))
+}
+
+// NewLockedSource wraps the with a mutex. To be used for concurrent access.
+func NewLockedSource(src rand.Source) rand.Source {
+	return &lockedSource{src: src}
+}
+
+type lockedSource struct {
+	l   sync.RWMutex
+	src rand.Source
+}
+
+func (s *lockedSource) Int63() int64 {
+	s.l.RLock()
+	defer s.l.RUnlock()
+
+	return s.src.Int63()
+}
+
+func (s *lockedSource) Seed(seed int64) {
+	s.l.Lock()
+	defer s.l.Unlock()
+
+	s.src.Seed(seed)
+}

--- a/random/locked_test.go
+++ b/random/locked_test.go
@@ -1,0 +1,23 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLockedSource(t *testing.T) {
+	s := NewMockSource()
+	l := NewLockedSource(s)
+
+	s.On("Int63").Return(int64(123)).Once()
+
+	require.Equal(t, int64(123), l.Int63())
+
+	s.AssertExpectations(t)
+}
+
+func TestNewLocked(t *testing.T) {
+	l := NewLocked()
+	require.NotEqual(t, l.Uint64(), l.Uint64())
+}

--- a/random/random.go
+++ b/random/random.go
@@ -1,0 +1,16 @@
+package random
+
+import (
+	"math/rand"
+	"time"
+)
+
+// New returns a rand.Rand seeded with the current time with nanoseconds precision.
+func New() *rand.Rand {
+	return rand.New(NewSource())
+}
+
+// NewSource returns a rand.Source seeded with the current time with nanoseconds precision.
+func NewSource() rand.Source {
+	return rand.NewSource(time.Now().UnixNano())
+}

--- a/random/seeded.go
+++ b/random/seeded.go
@@ -1,0 +1,14 @@
+package random
+
+import "math/rand"
+
+// NewSeeded returns a seeded rand.Rand.
+func NewSeeded(seed int64) *rand.Rand {
+	return rand.New(NewSeededSource(seed))
+}
+
+// NewSeededSource returns a seeded rand.Source, just like the rand package.
+// Provided for API completeness
+func NewSeededSource(seed int64) rand.Source {
+	return rand.NewSource(seed)
+}

--- a/random/seeded_test.go
+++ b/random/seeded_test.go
@@ -1,0 +1,14 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSeeded(t *testing.T) {
+	s := NewSeeded(123)
+	// Predictable output
+	require.Equal(t, uint64(0x4a68998bed5c40f1), s.Uint64())
+	require.Equal(t, uint64(0x835b51599210f9ba), s.Uint64())
+}

--- a/random/source_mock.go
+++ b/random/source_mock.go
@@ -1,0 +1,26 @@
+package random
+
+import (
+	"math/rand"
+
+	"github.com/stretchr/testify/mock"
+)
+
+var _ rand.Source = (*mockSource)(nil)
+
+// NewMockSource returns a mocked rand.Source. Configure each call before using.
+func NewMockSource() *mockSource {
+	return &mockSource{}
+}
+
+type mockSource struct {
+	mock.Mock
+}
+
+func (s *mockSource) Int63() int64 {
+	return s.Called().Get(0).(int64)
+}
+
+func (s *mockSource) Seed(seed int64) {
+	s.Called(seed)
+}

--- a/random/static.go
+++ b/random/static.go
@@ -1,0 +1,25 @@
+package random
+
+import "math/rand"
+
+// NewStatic returns a rand.Rand that always returns the same value. Useful for tests.
+func NewStatic(value int64) *rand.Rand {
+	return rand.New(NewStaticSource(value))
+}
+
+// NewStaticSource returns a rand.Source that always returns the same value. Useful for tests.
+func NewStaticSource(value int64) rand.Source {
+	return &staticSource{value}
+}
+
+type staticSource struct {
+	value int64
+}
+
+func (s *staticSource) Int63() int64 {
+	return s.value
+}
+
+func (s *staticSource) Seed(seed int64) {
+	s.value = seed
+}

--- a/random/static.go
+++ b/random/static.go
@@ -2,12 +2,12 @@ package random
 
 import "math/rand"
 
-// NewStatic returns a rand.Rand that always returns the same value. Useful for tests.
+// NewStatic returns a rand.Rand that always returns the seeded value. Useful for tests.
 func NewStatic(value int64) *rand.Rand {
 	return rand.New(NewStaticSource(value))
 }
 
-// NewStaticSource returns a rand.Source that always returns the same value. Useful for tests.
+// NewStaticSource returns a rand.Source that always returns the seeded value. Useful for tests.
 func NewStaticSource(value int64) rand.Source {
 	return &staticSource{value}
 }

--- a/random/static_test.go
+++ b/random/static_test.go
@@ -1,0 +1,12 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStatic(t *testing.T) {
+	s := NewStatic(123)
+	require.Equal(t, int64(123), s.Int63())
+}


### PR DESCRIPTION
Interface on top of `math/rand` to ease testing.

Idea expanded from https://github.com/Shopify/courier/tree/master/pkg/random

For production use:
- Standard: Seeded with the current time in nanoseconds.
- Locked: Wrapped in a mutex to protect concurrent access.

For tests:
- Dummy: Random, but deterministic output, same as Seeded(0).
- Mock: Mocked, needing to be configured before using.
- Static: Always the same output.
- Seeded: Random, but deterministic output.