### PR TITLE
Add resolver package

### DIFF
--- a/resolver/doc.go
+++ b/resolver/doc.go
@@ -1,0 +1,8 @@
+// Package resolver provides an interface and wrappers to the net.Resolver
+package resolver
+
+// Retry, defaulting to 3 tries will exponential backoff
+// Shuffle, to randomize the outputs because some systems to not randomize theirs.
+// Mock, for testing.
+//
+// resolver.New() will return a resolver wrapping the default net.Resolver in a shuffle and retry logic.

--- a/resolver/net_resolver.go
+++ b/resolver/net_resolver.go
@@ -1,0 +1,12 @@
+package resolver
+
+import (
+	"net"
+)
+
+func NewNetResolver(resolver *net.Resolver) Resolver {
+	if resolver == nil {
+		return net.DefaultResolver
+	}
+	return resolver
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,0 +1,33 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"net"
+)
+
+var ErrNotFound = errors.New("host not found")
+
+type Resolver interface {
+	LookupHost(ctx context.Context, host string) (addrs []string, err error)
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+	LookupPort(ctx context.Context, network, service string) (port int, err error)
+	LookupCNAME(ctx context.Context, host string) (cname string, err error)
+	LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error)
+	LookupMX(ctx context.Context, name string) ([]*net.MX, error)
+	LookupNS(ctx context.Context, name string) ([]*net.NS, error)
+	LookupTXT(ctx context.Context, name string) ([]string, error)
+	LookupAddr(ctx context.Context, addr string) (names []string, err error)
+}
+
+func New() (r Resolver) {
+	r = NewNetResolver(nil)
+	r = NewRetryResolver(r, nil)
+	r = NewShuffleResolver(r)
+	return r
+}
+
+func IsNotFound(err error) bool {
+	var dnsError *net.DNSError
+	return errors.As(err, &dnsError) && dnsError.IsNotFound
+}

--- a/resolver/resolver_mock.go
+++ b/resolver/resolver_mock.go
@@ -1,0 +1,90 @@
+package resolver
+
+import (
+	"context"
+	"net"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type mockResolver struct {
+	mock.Mock
+}
+
+var _ Resolver = (*mockResolver)(nil)
+
+func NewMockResolver() *mockResolver {
+	return &mockResolver{}
+}
+
+func (m *mockResolver) LookupHost(ctx context.Context, host string) (addrs []string, err error) {
+	args := m.Called(ctx, host)
+	if args.Error(1) != nil {
+		return addrs, args.Error(1)
+	}
+	return args.Get(0).([]string), nil
+}
+
+func (m *mockResolver) LookupIPAddr(ctx context.Context, host string) (records []net.IPAddr, err error) {
+	args := m.Called(ctx, host)
+	if args.Error(1) != nil {
+		return records, args.Error(1)
+	}
+	return args.Get(0).([]net.IPAddr), nil
+}
+
+func (m *mockResolver) LookupPort(ctx context.Context, network, service string) (port int, err error) {
+	args := m.Called(ctx, network, service)
+	if args.Error(1) != nil {
+		return port, args.Error(1)
+	}
+	return args.Int(0), nil
+}
+
+func (m *mockResolver) LookupCNAME(ctx context.Context, host string) (cname string, err error) {
+	args := m.Called(ctx, host)
+	if args.Error(1) != nil {
+		return cname, args.Error(1)
+	}
+	return args.String(0), nil
+}
+
+func (m *mockResolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, records []*net.SRV, err error) {
+	args := m.Called(ctx, service, proto, name)
+	if args.Error(2) != nil {
+		return cname, records, args.Error(2)
+	}
+	return args.String(0), args.Get(1).([]*net.SRV), nil
+}
+
+func (m *mockResolver) LookupMX(ctx context.Context, name string) (records []*net.MX, err error) {
+	args := m.Called(ctx, name)
+	if args.Error(1) != nil {
+		return records, args.Error(1)
+	}
+	return args.Get(0).([]*net.MX), nil
+}
+
+func (m *mockResolver) LookupNS(ctx context.Context, name string) (records []*net.NS, err error) {
+	args := m.Called(ctx, name)
+	if args.Error(1) != nil {
+		return records, args.Error(1)
+	}
+	return args.Get(0).([]*net.NS), nil
+}
+
+func (m *mockResolver) LookupTXT(ctx context.Context, name string) (records []string, err error) {
+	args := m.Called(ctx, name)
+	if args.Error(1) != nil {
+		return records, args.Error(1)
+	}
+	return args.Get(0).([]string), nil
+}
+
+func (m *mockResolver) LookupAddr(ctx context.Context, addr string) (names []string, err error) {
+	args := m.Called(ctx, addr)
+	if args.Error(1) != nil {
+		return names, args.Error(1)
+	}
+	return args.Get(0).([]string), nil
+}

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,0 +1,27 @@
+package resolver
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNotFound(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		isNotFound bool
+	}{
+		{"nil", nil, false},
+		{"foo", errors.New("foo"), false},
+		{"dns error", &net.DNSError{}, false},
+		{"dns not found error", &net.DNSError{IsNotFound: true}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.isNotFound, IsNotFound(tt.err))
+		})
+	}
+}

--- a/resolver/retry_resolver.go
+++ b/resolver/retry_resolver.go
@@ -1,0 +1,115 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+)
+
+// Perform one immediate retry to limit the introduction of delays during DNS resolutions
+var defaultRetryBackoffs = []time.Duration{0, 500 * time.Millisecond, 2 * time.Second}
+
+type retryResolver struct {
+	resolver Resolver
+	backoffs []time.Duration
+}
+
+func NewRetryResolver(resolver Resolver, backoffs []time.Duration) Resolver {
+	if backoffs == nil {
+		backoffs = defaultRetryBackoffs
+	}
+	return &retryResolver{
+		backoffs: backoffs,
+		resolver: resolver,
+	}
+}
+
+func (r *retryResolver) retry(fn func() error) (err error) {
+	err = fn()
+	for i := 0; i < len(r.backoffs) && err != nil && isTemporary(err); i++ {
+		time.Sleep(r.backoffs[i])
+		err = fn()
+	}
+	return err
+}
+
+func (r *retryResolver) LookupHost(ctx context.Context, host string) (addrs []string, err error) {
+	err = r.retry(func() (err error) {
+		addrs, err = r.resolver.LookupHost(ctx, host)
+		return err
+	})
+	return addrs, err
+}
+
+func (r *retryResolver) LookupIPAddr(ctx context.Context, host string) (records []net.IPAddr, err error) {
+	err = r.retry(func() (err error) {
+		records, err = r.resolver.LookupIPAddr(ctx, host)
+		return err
+	})
+	return records, err
+}
+
+func (r *retryResolver) LookupPort(ctx context.Context, network, service string) (port int, err error) {
+	err = r.retry(func() (err error) {
+		port, err = r.resolver.LookupPort(ctx, network, service)
+		return err
+	})
+	return port, err
+}
+
+func (r *retryResolver) LookupCNAME(ctx context.Context, host string) (cname string, err error) {
+	err = r.retry(func() (err error) {
+		cname, err = r.resolver.LookupCNAME(ctx, host)
+		return err
+	})
+	return cname, err
+}
+
+func (r *retryResolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, records []*net.SRV, err error) {
+	err = r.retry(func() (err error) {
+		cname, records, err = r.resolver.LookupSRV(ctx, service, proto, name)
+		return err
+	})
+	return cname, records, err
+}
+
+func (r *retryResolver) LookupMX(ctx context.Context, name string) (records []*net.MX, err error) {
+	err = r.retry(func() (err error) {
+		records, err = r.resolver.LookupMX(ctx, name)
+		return err
+	})
+	return records, err
+}
+
+func (r *retryResolver) LookupNS(ctx context.Context, name string) (records []*net.NS, err error) {
+	err = r.retry(func() (err error) {
+		records, err = r.resolver.LookupNS(ctx, name)
+		return err
+	})
+	return records, err
+}
+
+func (r *retryResolver) LookupTXT(ctx context.Context, name string) (records []string, err error) {
+	err = r.retry(func() (err error) {
+		records, err = r.resolver.LookupTXT(ctx, name)
+		return err
+	})
+	return records, err
+}
+
+func (r *retryResolver) LookupAddr(ctx context.Context, addr string) (names []string, err error) {
+	err = r.retry(func() (err error) {
+		names, err = r.resolver.LookupAddr(ctx, addr)
+		return err
+	})
+	return names, err
+}
+
+func isTemporary(err error) bool {
+	var dnsError *net.DNSError
+	if errors.As(err, &dnsError) && dnsError.Temporary() {
+		return true
+	}
+	return false
+}

--- a/resolver/retry_resolver_test.go
+++ b/resolver/retry_resolver_test.go
@@ -1,0 +1,169 @@
+package resolver
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var temporaryError = &net.DNSError{Name: "foo", Err: "bar", IsTemporary: true}
+var permanentError = &net.DNSError{Name: "foo", Err: "baz"}
+
+func withRetry(t *testing.T, fn func(m *mockResolver, r Resolver)) {
+	m := NewMockResolver()
+	r := NewRetryResolver(m, []time.Duration{0, 0}) // Do not actually sleep in tests.
+
+	fn(m, r)
+
+	m.AssertExpectations(t)
+}
+
+func makeErrorArgs(length int, err error) []interface{} {
+	args := make([]interface{}, length)
+	args[len(args)-1] = err
+	return args
+}
+
+func TestNewRetryLookup(t *testing.T) {
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		callArgs   []interface{}
+		returnArgs []interface{}
+		call       func(t *testing.T, r Resolver, success bool) error
+	}{
+		"LookupHost": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]string{"bar"}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				addrs, err := r.LookupHost(ctx, "foo")
+				if success {
+					require.Equal(t, []string{"bar"}, addrs)
+				}
+				return err
+			},
+		},
+		"LookupIPAddr": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]net.IPAddr{{Zone: "bar"}}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				records, err := r.LookupIPAddr(ctx, "foo")
+				if success {
+					require.Equal(t, []net.IPAddr{{Zone: "bar"}}, records)
+				}
+				return err
+			},
+		},
+		"LookupPort": {
+			callArgs:   []interface{}{ctx, "a", "b"},
+			returnArgs: []interface{}{123, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				port, err := r.LookupPort(ctx, "a", "b")
+				if success {
+					require.Equal(t, 123, port)
+				}
+				return err
+			},
+		},
+		"LookupCNAME": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{"bar", nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				cname, err := r.LookupCNAME(ctx, "foo")
+				if success {
+					require.Equal(t, "bar", cname)
+				}
+				return err
+			},
+		},
+		"LookupSRV": {
+			callArgs:   []interface{}{ctx, "a", "b", "c"},
+			returnArgs: []interface{}{"bar", []*net.SRV{{Target: "bar"}}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				cname, records, err := r.LookupSRV(ctx, "a", "b", "c")
+				if success {
+					require.Equal(t, "bar", cname)
+					require.Equal(t, []*net.SRV{{Target: "bar"}}, records)
+				}
+				return err
+			},
+		},
+		"LookupMX": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]*net.MX{{Host: "bar"}}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				records, err := r.LookupMX(ctx, "foo")
+				if success {
+					require.Equal(t, []*net.MX{{Host: "bar"}}, records)
+				}
+				return err
+			},
+		},
+		"LookupNS": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]*net.NS{{Host: "bar"}}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				records, err := r.LookupNS(ctx, "foo")
+				if success {
+					require.Equal(t, []*net.NS{{Host: "bar"}}, records)
+				}
+				return err
+			},
+		},
+		"LookupTXT": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]string{"bar"}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				records, err := r.LookupTXT(ctx, "foo")
+				if success {
+					require.Equal(t, []string{"bar"}, records)
+				}
+				return err
+			},
+		},
+		"LookupAddr": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]string{"bar"}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				names, err := r.LookupAddr(ctx, "foo")
+				if success {
+					require.Equal(t, []string{"bar"}, names)
+				}
+				return err
+			},
+		},
+	}
+
+	for method, tt := range tests {
+		t.Run(method, func(t *testing.T) {
+			t.Run("retry temporary", func(t *testing.T) {
+				withRetry(t, func(m *mockResolver, r Resolver) {
+					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), temporaryError)...).Once()
+					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), permanentError)...).Once()
+					err := tt.call(t, r, false)
+					require.EqualError(t, err, "lookup foo: baz")
+				})
+			})
+
+			t.Run("retry exhaustion", func(t *testing.T) {
+				withRetry(t, func(m *mockResolver, r Resolver) {
+					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), temporaryError)...).Times(3)
+					err := tt.call(t, r, false)
+					require.EqualError(t, err, "lookup foo: bar")
+				})
+			})
+
+			t.Run("success", func(t *testing.T) {
+				withRetry(t, func(m *mockResolver, r Resolver) {
+					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), temporaryError)...).Once()
+					m.On(method, tt.callArgs...).Return(tt.returnArgs...).Once()
+					err := tt.call(t, r, true)
+					require.NoError(t, err)
+				})
+			})
+		})
+	}
+}

--- a/resolver/shuffle_resolver.go
+++ b/resolver/shuffle_resolver.go
@@ -1,0 +1,85 @@
+package resolver
+
+import (
+	"context"
+	"math/rand"
+	"net"
+
+	"github.com/Shopify/goose/random"
+)
+
+type shuffleResolver struct {
+	lookup Resolver
+	rand   *rand.Rand
+}
+
+func NewShuffleResolver(lookup Resolver) Resolver {
+	return &shuffleResolver{
+		lookup: lookup,
+		rand:   random.New(),
+	}
+}
+
+func (r *shuffleResolver) LookupHost(ctx context.Context, host string) (addrs []string, err error) {
+	addrs, err = r.lookup.LookupHost(ctx, host)
+	r.rand.Shuffle(len(addrs), func(i, j int) {
+		addrs[i], addrs[j] = addrs[j], addrs[i]
+	})
+	return addrs, err
+}
+
+func (r *shuffleResolver) LookupIPAddr(ctx context.Context, host string) (addrs []net.IPAddr, err error) {
+	addrs, err = r.lookup.LookupIPAddr(ctx, host)
+	r.rand.Shuffle(len(addrs), func(i, j int) {
+		addrs[i], addrs[j] = addrs[j], addrs[i]
+	})
+	return addrs, err
+}
+
+func (r *shuffleResolver) LookupPort(ctx context.Context, network, service string) (port int, err error) {
+	return r.lookup.LookupPort(ctx, network, service)
+}
+
+func (r *shuffleResolver) LookupCNAME(ctx context.Context, host string) (cname string, err error) {
+	return r.lookup.LookupCNAME(ctx, host)
+}
+
+func (r *shuffleResolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	cname, addrs, err = r.lookup.LookupSRV(ctx, service, proto, name)
+	r.rand.Shuffle(len(addrs), func(i, j int) {
+		addrs[i], addrs[j] = addrs[j], addrs[i]
+	})
+	return cname, addrs, err
+}
+
+func (r *shuffleResolver) LookupMX(ctx context.Context, name string) (records []*net.MX, err error) {
+	records, err = r.lookup.LookupMX(ctx, name)
+	r.rand.Shuffle(len(records), func(i, j int) {
+		records[i], records[j] = records[j], records[i]
+	})
+	return records, err
+}
+
+func (r *shuffleResolver) LookupNS(ctx context.Context, name string) (records []*net.NS, err error) {
+	records, err = r.lookup.LookupNS(ctx, name)
+	r.rand.Shuffle(len(records), func(i, j int) {
+		records[i], records[j] = records[j], records[i]
+	})
+	return records, err
+}
+
+func (r *shuffleResolver) LookupTXT(ctx context.Context, name string) (records []string, err error) {
+	records, err = r.lookup.LookupTXT(ctx, name)
+	r.rand.Shuffle(len(records), func(i, j int) {
+		records[i], records[j] = records[j], records[i]
+	})
+	return records, err
+}
+
+func (r *shuffleResolver) LookupAddr(ctx context.Context, addr string) (names []string, err error) {
+	names, err = r.lookup.LookupAddr(ctx, addr)
+	r.rand.Shuffle(len(names), func(i, j int) {
+		names[i], names[j] = names[j], names[i]
+	})
+	return names, err
+}

--- a/resolver/shuffle_resolver_test.go
+++ b/resolver/shuffle_resolver_test.go
@@ -1,0 +1,152 @@
+package resolver
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/Shopify/goose/random"
+
+	"github.com/stretchr/testify/require"
+)
+
+func withShuffle(t *testing.T, fn func(m *mockResolver, r Resolver)) {
+	m := NewMockResolver()
+	r := NewShuffleResolver(m).(*shuffleResolver)
+	r.rand = random.NewDummy()
+
+	fn(m, r)
+
+	m.AssertExpectations(t)
+}
+
+func TestNewShuffleResolver(t *testing.T) {
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		callArgs   []interface{}
+		returnArgs []interface{}
+		call       func(t *testing.T, r Resolver, success bool) error
+	}{
+		"LookupHost": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]string{"bar", "baz", "qux"}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				addrs, err := r.LookupHost(ctx, "foo")
+				if success {
+					require.Equal(t, []string{"baz", "bar", "qux"}, addrs)
+				}
+				return err
+			},
+		},
+		"LookupIPAddr": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]net.IPAddr{{Zone: "bar"}, {Zone: "baz"}, {Zone: "qux"}}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				records, err := r.LookupIPAddr(ctx, "foo")
+				if success {
+					require.Equal(t, []net.IPAddr{{Zone: "baz"}, {Zone: "bar"}, {Zone: "qux"}}, records)
+				}
+				return err
+			},
+		},
+		"LookupPort": {
+			callArgs:   []interface{}{ctx, "a", "b"},
+			returnArgs: []interface{}{123, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				port, err := r.LookupPort(ctx, "a", "b")
+				if success {
+					require.Equal(t, 123, port)
+				}
+				return err
+			},
+		},
+		"LookupCNAME": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{"bar", nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				cname, err := r.LookupCNAME(ctx, "foo")
+				if success {
+					require.Equal(t, "bar", cname)
+				}
+				return err
+			},
+		},
+		"LookupSRV": {
+			callArgs:   []interface{}{ctx, "a", "b", "c"},
+			returnArgs: []interface{}{"bar", []*net.SRV{{Target: "bar"}, {Target: "baz"}, {Target: "qux"}}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				cname, records, err := r.LookupSRV(ctx, "a", "b", "c")
+				if success {
+					require.Equal(t, "bar", cname)
+					require.Equal(t, []*net.SRV{{Target: "baz"}, {Target: "bar"}, {Target: "qux"}}, records)
+				}
+				return err
+			},
+		},
+		"LookupMX": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]*net.MX{{Host: "bar"}, {Host: "baz"}, {Host: "qux"}}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				records, err := r.LookupMX(ctx, "foo")
+				if success {
+					require.Equal(t, []*net.MX{{Host: "baz"}, {Host: "bar"}, {Host: "qux"}}, records)
+				}
+				return err
+			},
+		},
+		"LookupNS": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]*net.NS{{Host: "bar"}}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				records, err := r.LookupNS(ctx, "foo")
+				if success {
+					require.Equal(t, []*net.NS{{Host: "bar"}}, records)
+				}
+				return err
+			},
+		},
+		"LookupTXT": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]string{"bar", "baz", "qux"}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				records, err := r.LookupTXT(ctx, "foo")
+				if success {
+					require.Equal(t, []string{"baz", "bar", "qux"}, records)
+				}
+				return err
+			},
+		},
+		"LookupAddr": {
+			callArgs:   []interface{}{ctx, "foo"},
+			returnArgs: []interface{}{[]string{"bar", "baz", "qux"}, nil},
+			call: func(t *testing.T, r Resolver, success bool) error {
+				names, err := r.LookupAddr(ctx, "foo")
+				if success {
+					require.Equal(t, []string{"baz", "bar", "qux"}, names)
+				}
+				return err
+			},
+		},
+	}
+
+	for method, tt := range tests {
+		t.Run(method, func(t *testing.T) {
+			t.Run("error", func(t *testing.T) {
+				withShuffle(t, func(m *mockResolver, r Resolver) {
+					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), temporaryError)...).Once()
+					err := tt.call(t, r, false)
+					require.EqualError(t, err, "lookup foo: bar")
+				})
+			})
+
+			t.Run("success", func(t *testing.T) {
+				withShuffle(t, func(m *mockResolver, r Resolver) {
+					m.On(method, tt.callArgs...).Return(tt.returnArgs...).Once()
+					err := tt.call(t, r, true)
+					require.NoError(t, err)
+				})
+			})
+		})
+	}
+}


### PR DESCRIPTION
Depends on https://github.com/Shopify/goose/pull/54

Adds a missing interface to the `net.Resolver` and provides wrappers:

- Retry, defaulting to 3 tries will exponential backoff
- Shuffle, to random the output because some systems some randomize their lookups.
- Mock, for testing.

Idea expanded from https://github.com/Shopify/courier/blob/master/pkg/dns/lookup.go

- [x] Write package doc
- [x] Add more tests
