### PR TITLE
Use locked rand.Source for shuffle resolver

### DIFF
--- a/resolver/shuffle_resolver.go
+++ b/resolver/shuffle_resolver.go
@@ -16,7 +16,7 @@ type shuffleResolver struct {
 func NewShuffleResolver(lookup Resolver) Resolver {
 	return &shuffleResolver{
 		lookup: lookup,
-		rand:   random.New(),
+		rand:   random.NewLocked(),
 	}
 }
 


### PR DESCRIPTION
This PR change the `rand.Source` used in the shuffle resolver by a thread safe `rand.Source`.
It actually makes Courier panicking, since we use the resolver concurrently.
⚠️ This change is global for all the users of the shuffle resolver, but there's no breaking change.