### PR TITLE
Add a concurrency limiter

### DIFF
--- a/concurrency/limiter.go
+++ b/concurrency/limiter.go
@@ -1,0 +1,124 @@
+package concurrency
+
+import (
+	"context"
+	"sync/atomic"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/Shopify/goose/statsd"
+)
+
+const NoLimit uint = 0
+
+type Limiter interface {
+	// Run executes a function, making sure at most a certain number of calls are executing simultaneously
+	// It does _not_ start a goroutine, the function will be executing on the caller's stack.
+	// If the context is canceled while waiting, it will abort.
+	Run(ctx context.Context, fn func() error) error
+
+	// Waiting returns a (racy) counter of how many Run calls are currently waiting to run.
+	Waiting() int32
+
+	// Running returns a (racy) counter of how many Run calls are currently executing their function.
+	Running() int32
+
+	MaxConcurrency() uint
+}
+
+type gaugor interface {
+	Gauge(ctx context.Context, n float64, ts ...statsd.Tags)
+}
+
+type limiter struct {
+	semaphore     *semaphore.Weighted
+	concurrency   uint
+	waiting       int32
+	running       int32
+	gauge         gaugor
+	tags          statsd.Tags
+	sampling      int32
+	sampleCounter int32
+}
+
+func NewLimiter(concurrency uint) Limiter {
+	return NewLimiterWithGauge(concurrency, nil, nil)
+}
+
+func NewLimiterWithGauge(concurrency uint, gauge gaugor, tags statsd.Tags) Limiter {
+	return NewLimiterWithSampledGauge(concurrency, gauge, 0, tags)
+}
+
+func NewGauge(gauge gaugor, tags statsd.Tags) Limiter {
+	return NewSampledGauge(gauge, 0, tags)
+}
+
+func NewSampledGauge(gauge gaugor, sampling int32, tags statsd.Tags) Limiter {
+	return NewLimiterWithSampledGauge(NoLimit, gauge, sampling, tags)
+}
+
+// NewLimiterWithSampledGauge creates a Limiter that will publish the a gauge every <sampling> Run
+func NewLimiterWithSampledGauge(concurrency uint, gauge gaugor, sampling int32, tags statsd.Tags) Limiter {
+	limiter := &limiter{
+		concurrency: concurrency,
+		gauge:       gauge,
+		sampling:    sampling,
+		tags:        tags,
+	}
+	if concurrency > 0 {
+		limiter.semaphore = semaphore.NewWeighted(int64(concurrency))
+	}
+	return limiter
+}
+
+func (c *limiter) Run(ctx context.Context, fn func() error) error {
+	if c.semaphore != nil {
+		if err := c.acquire(ctx); err != nil {
+			return err
+		}
+		defer c.semaphore.Release(1)
+	}
+
+	return c.run(ctx, fn)
+}
+
+func (c *limiter) acquire(ctx context.Context) error {
+	c.deltaAndMaybePublish(ctx, &c.waiting, 1, "waiting")
+	defer c.deltaAndMaybePublish(ctx, &c.waiting, -1, "waiting")
+
+	return c.semaphore.Acquire(ctx, 1)
+}
+
+func (c *limiter) run(ctx context.Context, fn func() error) error {
+	c.deltaAndMaybePublish(ctx, &c.running, 1, "running")
+	defer c.deltaAndMaybePublish(ctx, &c.running, -1, "running")
+
+	return fn()
+}
+
+func (c *limiter) deltaAndMaybePublish(ctx context.Context, ptr *int32, delta int32, state string) {
+	current := atomic.AddInt32(ptr, delta)
+
+	if c.gauge == nil {
+		return
+	}
+	if c.sampling > 0 {
+		counter := atomic.AddInt32(&c.sampleCounter, 1) // will overflow and loop gracefully.
+		if counter%c.sampling > 0 {
+			return
+		}
+	}
+	c.gauge.Gauge(ctx, float64(current), statsd.Tags{"state": state}, c.tags)
+}
+
+func (c *limiter) Waiting() int32 {
+	return atomic.LoadInt32(&c.waiting)
+}
+
+func (c *limiter) Running() int32 {
+	return atomic.LoadInt32(&c.running)
+}
+
+func (c *limiter) MaxConcurrency() uint {
+	return c.concurrency
+}

--- a/concurrency/limiter_mock.go
+++ b/concurrency/limiter_mock.go
@@ -1,0 +1,37 @@
+package concurrency
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+var _ Limiter = &mockLimiter{}
+
+func NewMockLimiter(stubRun bool) *mockLimiter {
+	return &mockLimiter{stubRun: stubRun}
+}
+
+type mockLimiter struct {
+	mock.Mock
+	stubRun bool
+}
+
+func (l *mockLimiter) MaxConcurrency() uint {
+	return l.Called().Get(0).(uint)
+}
+
+func (l *mockLimiter) Waiting() int32 {
+	return l.Called().Get(0).(int32)
+}
+
+func (l *mockLimiter) Running() int32 {
+	return l.Called().Get(0).(int32)
+}
+
+func (l *mockLimiter) Run(ctx context.Context, fn func() error) error {
+	if l.stubRun {
+		return fn()
+	}
+	return l.Called(ctx, fn).Error(0)
+}

--- a/concurrency/limiter_test.go
+++ b/concurrency/limiter_test.go
@@ -1,0 +1,182 @@
+package concurrency
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// concurrency_0-8         	 1000000	      1891 ns/op
+// concurrency_1-8         	  432932	      3447 ns/op
+// concurrency_10-8        	  650433	      5317 ns/op
+// concurrency_100-8       	  819081	      2538 ns/op
+func BenchmarkLimiter(b *testing.B) {
+	concurrencies := []uint{NoLimit, 1, 10, 100}
+
+	for _, concurrency := range concurrencies {
+		b.Run(fmt.Sprintf("concurrency %d", concurrency), func(b *testing.B) {
+			limiter := NewLimiter(concurrency)
+			ctx := context.Background()
+
+			wg := sync.WaitGroup{}
+			wg.Add(b.N)
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				go func() {
+					_ = limiter.Run(ctx, func() error {
+						time.Sleep(time.Nanosecond) // Force the scheduler for a more meaningful test
+						return nil
+					})
+					wg.Done()
+				}()
+			}
+
+			wg.Wait()
+		})
+	}
+}
+
+func TestConcurrencyLimiter_cancel(t *testing.T) {
+	limiter := NewLimiter(1)
+	ctx := context.Background()
+
+	// Queue is empty, it doesn't matter if the context is canceled.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.NoError(t, limiter.Run(ctx, func() error { return nil }))
+
+	started := make(chan struct{})
+	wait := make(chan struct{})
+	done := make(chan error)
+	go func() {
+		done <- limiter.Run(ctx, func() error {
+			close(started)
+			<-wait
+			return nil
+		})
+	}()
+
+	<-started
+
+	err := limiter.Run(cancelCtx, func() error { return nil })
+	require.EqualError(t, err, "context canceled")
+
+	close(wait)
+	require.NoError(t, <-done)
+}
+
+func expectCount(t *testing.T, call func() int32, expected int32) {
+	for i := 0; i < 20; i++ {
+		if call() == expected {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.Failf(t, "wrong count", "expect count to be %d, but it's stuck at %d", expected, call())
+}
+
+func TestConcurrencyLimiter_stats(t *testing.T) {
+	limiter := NewLimiter(2)
+	ctx := context.Background()
+
+	wait := make(chan struct{})
+	done := make(chan error)
+
+	queue := func() {
+		done <- limiter.Run(ctx, func() error {
+			<-wait
+			return nil
+		})
+	}
+
+	require.Equal(t, int32(0), limiter.Waiting())
+	require.Equal(t, int32(0), limiter.Running())
+
+	go queue()
+	go queue()
+	go queue()
+
+	expectCount(t, limiter.Running, 2)
+	expectCount(t, limiter.Waiting, 1)
+
+	wait <- struct{}{}
+	require.NoError(t, <-done)
+	expectCount(t, limiter.Waiting, 0)
+	expectCount(t, limiter.Running, 2)
+
+	wait <- struct{}{}
+	require.NoError(t, <-done)
+	expectCount(t, limiter.Waiting, 0)
+	expectCount(t, limiter.Running, 1)
+
+	wait <- struct{}{}
+	require.NoError(t, <-done)
+
+	require.Equal(t, int32(0), limiter.Waiting())
+	require.Equal(t, int32(0), limiter.Running())
+}
+
+func TestConcurrencyLimiter_random(t *testing.T) {
+	runs := 1000
+	concurrency := uint(10)
+
+	limiter := NewLimiter(concurrency)
+	require.Equal(t, concurrency, limiter.MaxConcurrency())
+	ctx := context.Background()
+
+	done := make(chan error)
+
+	for i := 0; i <= runs; i++ {
+		go func() {
+			done <- limiter.Run(ctx, func() error {
+				time.Sleep(time.Duration(rand.Float64()) * 100 * time.Millisecond)
+				return nil
+			})
+		}()
+	}
+
+	for i := 0; i <= runs; i++ {
+		require.NoError(t, <-done)
+	}
+
+	require.Equal(t, int32(0), limiter.Waiting())
+	require.Equal(t, int32(0), limiter.Running())
+}
+
+func TestConcurrencyLimiter_unlimited(t *testing.T) {
+	limiter := NewLimiter(0)
+	require.Equal(t, uint(0), limiter.MaxConcurrency())
+	ctx := context.Background()
+
+	wait := make(chan struct{})
+	done := make(chan error)
+
+	queue := func() {
+		done <- limiter.Run(ctx, func() error {
+			<-wait
+			return nil
+		})
+	}
+
+	go queue()
+	go queue()
+
+	expectCount(t, limiter.Waiting, 0)
+	expectCount(t, limiter.Running, 2)
+
+	wait <- struct{}{}
+	wait <- struct{}{}
+
+	require.NoError(t, <-done)
+	require.NoError(t, <-done)
+
+	require.Equal(t, int32(0), limiter.Waiting())
+	require.Equal(t, int32(0), limiter.Running())
+}


### PR DESCRIPTION
Run executes a function, making sure at most a certain number of calls are executing simultaneously
It does _not_ start a goroutine, the function will be executing on the caller's stack.
If the context is canceled while waiting, it will abort.

The limiter can optionally be configured with a Gaugor and a sample rate on the metric publication