### PR TITLE
Add a throttler

### DIFF
--- a/concurrency/throttler.go
+++ b/concurrency/throttler.go
@@ -1,0 +1,47 @@
+package concurrency
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Shopify/goose/timetracker"
+)
+
+func NewThrottler(limiter Limiter, tracker timetracker.Tracker, waitTimeout time.Duration) Throttler {
+	return &throttler{
+		limiter:     limiter,
+		tracker:     tracker,
+		waitTimeout: waitTimeout,
+	}
+}
+
+type Throttler interface {
+	Run(ctx context.Context, fn func() error) error
+}
+
+type ErrThrottled struct {
+	WaitTime time.Duration
+}
+
+func (t *ErrThrottled) Error() string {
+	return fmt.Sprintf("throttled, retry after %.02f seconds", t.WaitTime.Seconds())
+}
+
+type throttler struct {
+	limiter     Limiter
+	tracker     timetracker.Tracker
+	waitTimeout time.Duration
+}
+
+func (t *throttler) Run(ctx context.Context, fn func() error) error {
+	if waitTime := EstimatedWaitTime(t.limiter, t.tracker.Average()); waitTime > t.waitTimeout {
+		return &ErrThrottled{waitTime}
+	}
+
+	return t.limiter.Run(ctx, func() error {
+		defer t.tracker.Start().Finish()
+
+		return fn()
+	})
+}

--- a/concurrency/throttler_middleware.go
+++ b/concurrency/throttler_middleware.go
@@ -1,0 +1,24 @@
+package concurrency
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+func ThrottlerMiddleware(th Throttler) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := th.Run(r.Context(), func() error {
+				next.ServeHTTP(w, r)
+				return nil
+			})
+
+			var throttled *ErrThrottled
+			if errors.As(err, &throttled) {
+				w.Header().Set("Retry-After", fmt.Sprintf("%d", int(throttled.WaitTime.Seconds())))
+				w.WriteHeader(http.StatusTooManyRequests)
+			}
+		})
+	}
+}

--- a/concurrency/throttler_middleware_test.go
+++ b/concurrency/throttler_middleware_test.go
@@ -1,0 +1,42 @@
+package concurrency
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThrottlerMiddleware(t *testing.T) {
+	th := NewMockThrottler(true)
+	m := ThrottlerMiddleware(th)
+
+	t.Run("handle", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/", nil)
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("ok"))
+		})
+
+		th.On("Run", mock.Anything, mock.Anything).Return(nil).Once()
+		m(next).ServeHTTP(w, r)
+		require.Equal(t, "ok", w.Body.String())
+
+		th.AssertExpectations(t)
+	})
+
+	t.Run("busy", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/", nil)
+
+		th.On("Run", mock.Anything, mock.Anything).Return(&ErrThrottled{WaitTime: 3 * time.Second}).Once()
+		m(nil).ServeHTTP(w, r)
+		require.Equal(t, "3", w.Header().Get("Retry-After"))
+		require.Equal(t, http.StatusTooManyRequests, w.Code)
+
+		th.AssertExpectations(t)
+	})
+}

--- a/concurrency/throttler_mock.go
+++ b/concurrency/throttler_mock.go
@@ -1,0 +1,29 @@
+package concurrency
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+var _ Throttler = (*mockThrottler)(nil)
+
+func NewMockThrottler(run bool) *mockThrottler {
+	return &mockThrottler{run: run}
+}
+
+type mockThrottler struct {
+	mock.Mock
+	run bool
+}
+
+func (m *mockThrottler) Run(ctx context.Context, fn func() error) error {
+	args := m.Called(ctx, fn)
+	if err := args.Error(0); err != nil {
+		return err
+	}
+	if m.run {
+		return fn()
+	}
+	return nil
+}

--- a/concurrency/throttler_test.go
+++ b/concurrency/throttler_test.go
@@ -1,0 +1,48 @@
+package concurrency
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Shopify/goose/timetracker"
+)
+
+func TestThrottler(t *testing.T) {
+	ctx := context.Background()
+	mockLimiter := NewMockLimiter(true)
+	mockTracker := timetracker.NewMockTracker(true)
+
+	th := NewThrottler(mockLimiter, mockTracker, 2*time.Second)
+
+	t.Run("free", func(t *testing.T) {
+		mockTracker.On("Average").Return(1 * time.Second).Once()
+		mockLimiter.On("MaxConcurrency").Return(uint(1)).Once()
+		mockLimiter.On("Waiting").Return(int32(2)).Once()
+
+		var ran bool
+		err := th.Run(ctx, func() error {
+			ran = true
+			return nil
+		})
+		require.NoError(t, err)
+		require.True(t, ran)
+
+		mockLimiter.AssertExpectations(t)
+		mockTracker.AssertExpectations(t)
+	})
+
+	t.Run("busy", func(t *testing.T) {
+		mockLimiter.On("MaxConcurrency").Return(uint(1)).Once()
+		mockLimiter.On("Waiting").Return(int32(3)).Once()
+		mockTracker.On("Average").Return(1 * time.Second).Once()
+
+		err := th.Run(ctx, nil)
+		require.Equal(t, &ErrThrottled{3 * time.Second}, err)
+
+		mockLimiter.AssertExpectations(t)
+		mockTracker.AssertExpectations(t)
+	})
+}

--- a/concurrency/wait_time.go
+++ b/concurrency/wait_time.go
@@ -1,0 +1,16 @@
+package concurrency
+
+import "time"
+
+func EstimatedWaitTime(limiter Limiter, average time.Duration) time.Duration {
+	if average <= 0 {
+		return 0
+	}
+
+	concurrency := limiter.MaxConcurrency()
+	if concurrency == 0 {
+		return 0
+	}
+
+	return time.Duration(int64(average) / int64(concurrency) * int64(limiter.Waiting()))
+}

--- a/concurrency/wait_time_test.go
+++ b/concurrency/wait_time_test.go
@@ -1,0 +1,35 @@
+package concurrency
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimatedWaitTime(t *testing.T) {
+	tests := []struct {
+		concurrency uint
+		waiting     int32
+		average     time.Duration
+		want        time.Duration
+	}{
+		{concurrency: 0, waiting: 10, average: 10 * time.Second, want: 0},
+		{concurrency: 10, waiting: 0, average: 10 * time.Second, want: 0},
+		{concurrency: 10, waiting: 10, average: 0, want: 0},
+		{concurrency: 5, waiting: 10, average: 10 * time.Second, want: 20 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v/%v/%v", tt.concurrency, tt.waiting, tt.average), func(t *testing.T) {
+			limiter := NewMockLimiter(false)
+			limiter.On("MaxConcurrency").Return(tt.concurrency).Maybe()
+			limiter.On("Waiting").Return(tt.waiting).Maybe()
+
+			estimate := EstimatedWaitTime(limiter, tt.average)
+			require.Equal(t, tt.want, estimate)
+
+			limiter.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
Combine the time tracker of https://github.com/Shopify/goose/pull/58 and the concurrency limiter of https://github.com/Shopify/goose/pull/59 to create a throttler, which tries to estimate the time a call to Run would have to wait. 

If the estimate is higher than the maximum allowed, `ErrThrottled` is returned.

Comes with an HTTP middleware that will write a `Retry-After` header with the number of seconds to wait.