### PR TITLE
Update Go to 1.15

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,8 +58,8 @@ jobs:
       matrix:
         go-version:
         - 1.13.x
-#        - 1.14.x
-#        - 1.15.x
+        - 1.14.x
+        - 1.15.x
 
     steps:
     - name: Checkout

--- a/bugsnag/bugsnagger_test.go
+++ b/bugsnag/bugsnagger_test.go
@@ -79,12 +79,13 @@ func TestBuildDataError_wrappedCause(t *testing.T) {
 
 func TestBuildDataError_urlError(t *testing.T) {
 	// url error
-	err := errors.Wrap(&url.Error{Op: "GET", URL: "lol.com", Err: errors.New("err")}, "url fail")
+	urlError := &url.Error{Op: "GET", URL: "lol.com", Err: errors.New("err")}
+	err := errors.Wrap(urlError, "url fail")
 	dataList, err := mSnagger.buildData(err)
 	require.Equal(t, "err", err.Error())
-	require.Equal(t, "GET lol.com: err", newBugsnagData(dataList).getBugsnaggoErrorClass())
+	require.Equal(t, urlError.Error(), newBugsnagData(dataList).getBugsnaggoErrorClass())
 	require.True(t, newBugsnagData(dataList).hasErrTab())
-	require.Equal(t, "url fail: GET lol.com", newBugsnagData(dataList).getContext())
+	require.Equal(t, "url fail: "+urlError.Error(), newBugsnagData(dataList).getContext()+": err")
 }
 
 func TestBuildDataError_http2Stream(t *testing.T) {

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ name: goose
 
 up:
   - go:
-      version: "1.13.7"
+      version: "1.15.3"
       modules: true
 
 commands:

--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -86,8 +87,8 @@ func TestNewServer(t *testing.T) {
 
 	// No longer works
 	res, err = http.Get(u)
-	errMsg := fmt.Sprintf("Get %s: dial tcp %s: connect: connection refused", u, s.Addr().String())
-	assert.EqualError(t, err, errMsg)
+	assert.NotNil(t, err)
+	assert.True(t, strings.HasSuffix(err.Error(), ": connection refused"))
 	assert.Nil(t, res)
 }
 
@@ -166,8 +167,8 @@ func TestNewServerFromFactory(t *testing.T) {
 
 	// No longer works
 	res, err = http.Get(u)
-	errMsg := fmt.Sprintf("Get %s: dial tcp %s: connect: connection refused", u, s.Addr().String())
-	assert.EqualError(t, err, errMsg)
+	assert.NotNil(t, err)
+	assert.True(t, strings.HasSuffix(err.Error(), ": connection refused"))
 	assert.Nil(t, res)
 }
 
@@ -232,7 +233,7 @@ func TestStoppableKeepaliveListener_Accept(t *testing.T) {
 
 	// No longer works
 	res, err := http.Get(u)
-	errMsg := fmt.Sprintf("Get %s: dial tcp %s: connect: connection refused", u, s.Addr().String())
-	assert.EqualError(t, err, errMsg)
+	assert.NotNil(t, err)
+	assert.True(t, strings.HasSuffix(err.Error(), ": connection refused"))
 	assert.Nil(t, res)
 }


### PR DESCRIPTION
- Adapt tests to work on Go 1.15 because the error string for network errors has changed
- Enable CI tests on 1.14 and 1.15
- Keep 1.13 compatibility