### PR TITLE
Add statsd.Timing

### DIFF
--- a/statsd/timing.go
+++ b/statsd/timing.go
@@ -1,0 +1,17 @@
+package statsd
+
+import (
+	"context"
+	"time"
+)
+
+// Timing represents a timing-type metric, which takes durations and includes percentiles, means, and other information
+// along with the event.
+// https://github.com/statsd/statsd/blob/master/docs/metric_types.md#timing
+type Timing collector
+
+// Duration takes a time.Duration  -- the time the operation took -- and submits it to StatsD.
+func (t *Timing) Duration(ctx context.Context, n time.Duration, ts ...Tags) {
+	tags := getStatsTags(ctx, ts...)
+	warnIfError(ctx, currentBackend.Timing(ctx, t.Name, n, tags, t.Rate.Rate()))
+}

--- a/statsd/timing_test.go
+++ b/statsd/timing_test.go
@@ -1,0 +1,22 @@
+package statsd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Shopify/goose/statsd/mocks"
+)
+
+func TestTiming(t *testing.T) {
+	defer func() { SetBackend(NewNullBackend()) }()
+
+	ctx := WithTags(context.Background(), Tags{"test": "value"})
+	dur := 1 * time.Millisecond
+	statsd := new(mocks.Backend)
+	statsd.On("Timing", ctx, "metric", dur, []string{"test:value"}, 1.0).Return(nil)
+
+	SetBackend(statsd)
+	metric := &Timing{Name: "metric"}
+	metric.Duration(ctx, dur)
+}


### PR DESCRIPTION
Similar to what we've done for counters, gauges, etc. I've added `statsd.Timing` to make it possible to use the `Timing` call without passing around the backend implementation.