### PR TITLE
Fix cond random test

### DIFF
--- a/cond/cond_test.go
+++ b/cond/cond_test.go
@@ -393,7 +393,7 @@ func TestCond_Signal_random(t *testing.T) {
 		t.Fatal("test timeout")
 	}
 
-	assert.InDelta(t, threads, successes, float64(3*threads/4), "roughly a quarter of the threads should succeed")
+	assert.InDelta(t, 0.5, float64(successes)/float64(threads), 0.2, "roughly half of the threads should succeed")
 }
 
 func TestCondSignalStealing(t *testing.T) {


### PR DESCRIPTION
After think about it some more, I realized that Wait could receive a
signal from a previous iteration, so it's 1/4 success, but in both directions.

Therefore, the expected ratio of success is closer to 50%