### PR TITLE
Attach error LogFields to ContextLog

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -53,6 +53,12 @@ func ContextLog(ctx Valuer, err []error, entry *logrus.Entry) *logrus.Entry {
 				entry = entry.WithField(fmt.Sprintf("cause%d", i+1), errors.Cause(errX))
 			}
 		}
+
+		// Check last, to allow LogFields to overwrite this package's behaviour.
+		// Do not recurse in error causes, the error itself should merge its causes' fields if desired.
+		if logFields, ok := err0.(interface{ LogFields() logrus.Fields }); ok {
+			entry = entry.WithFields(logFields.LogFields())
+		}
 	}
 
 	return entry


### PR DESCRIPTION
If the error exposes LogFields, attach them to log entry.

Paves the way to allow attaching fields to an error before bubbling it up. 
The context in which the error occurs sometimes has more information than where the error is reported.