### PR TITLE
Cancel retry resolver sleep if context is canceled

### DIFF
--- a/resolver/retry_resolver_test.go
+++ b/resolver/retry_resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,12 +55,12 @@ func TestNewRetryLookup(t *testing.T) {
 	tests := map[string]struct {
 		callArgs   []interface{}
 		returnArgs []interface{}
-		call       func(t *testing.T, r Resolver, success bool) error
+		call       func(ctx context.Context, t *testing.T, r Resolver, success bool) error
 	}{
 		"LookupHost": {
-			callArgs:   []interface{}{ctx, "foo"},
+			callArgs:   []interface{}{mock.Anything, "foo"},
 			returnArgs: []interface{}{[]string{"bar"}, nil},
-			call: func(t *testing.T, r Resolver, success bool) error {
+			call: func(ctx context.Context, t *testing.T, r Resolver, success bool) error {
 				addrs, err := r.LookupHost(ctx, "foo")
 				if success {
 					require.Equal(t, []string{"bar"}, addrs)
@@ -68,9 +69,9 @@ func TestNewRetryLookup(t *testing.T) {
 			},
 		},
 		"LookupIPAddr": {
-			callArgs:   []interface{}{ctx, "foo"},
+			callArgs:   []interface{}{mock.Anything, "foo"},
 			returnArgs: []interface{}{[]net.IPAddr{{Zone: "bar"}}, nil},
-			call: func(t *testing.T, r Resolver, success bool) error {
+			call: func(ctx context.Context, t *testing.T, r Resolver, success bool) error {
 				records, err := r.LookupIPAddr(ctx, "foo")
 				if success {
 					require.Equal(t, []net.IPAddr{{Zone: "bar"}}, records)
@@ -79,9 +80,9 @@ func TestNewRetryLookup(t *testing.T) {
 			},
 		},
 		"LookupPort": {
-			callArgs:   []interface{}{ctx, "a", "b"},
+			callArgs:   []interface{}{mock.Anything, "a", "b"},
 			returnArgs: []interface{}{123, nil},
-			call: func(t *testing.T, r Resolver, success bool) error {
+			call: func(ctx context.Context, t *testing.T, r Resolver, success bool) error {
 				port, err := r.LookupPort(ctx, "a", "b")
 				if success {
 					require.Equal(t, 123, port)
@@ -90,9 +91,9 @@ func TestNewRetryLookup(t *testing.T) {
 			},
 		},
 		"LookupCNAME": {
-			callArgs:   []interface{}{ctx, "foo"},
+			callArgs:   []interface{}{mock.Anything, "foo"},
 			returnArgs: []interface{}{"bar", nil},
-			call: func(t *testing.T, r Resolver, success bool) error {
+			call: func(ctx context.Context, t *testing.T, r Resolver, success bool) error {
 				cname, err := r.LookupCNAME(ctx, "foo")
 				if success {
 					require.Equal(t, "bar", cname)
@@ -101,9 +102,9 @@ func TestNewRetryLookup(t *testing.T) {
 			},
 		},
 		"LookupSRV": {
-			callArgs:   []interface{}{ctx, "a", "b", "c"},
+			callArgs:   []interface{}{mock.Anything, "a", "b", "c"},
 			returnArgs: []interface{}{"bar", []*net.SRV{{Target: "bar"}}, nil},
-			call: func(t *testing.T, r Resolver, success bool) error {
+			call: func(ctx context.Context, t *testing.T, r Resolver, success bool) error {
 				cname, records, err := r.LookupSRV(ctx, "a", "b", "c")
 				if success {
 					require.Equal(t, "bar", cname)
@@ -113,9 +114,9 @@ func TestNewRetryLookup(t *testing.T) {
 			},
 		},
 		"LookupMX": {
-			callArgs:   []interface{}{ctx, "foo"},
+			callArgs:   []interface{}{mock.Anything, "foo"},
 			returnArgs: []interface{}{[]*net.MX{{Host: "bar"}}, nil},
-			call: func(t *testing.T, r Resolver, success bool) error {
+			call: func(ctx context.Context, t *testing.T, r Resolver, success bool) error {
 				records, err := r.LookupMX(ctx, "foo")
 				if success {
 					require.Equal(t, []*net.MX{{Host: "bar"}}, records)
@@ -124,9 +125,9 @@ func TestNewRetryLookup(t *testing.T) {
 			},
 		},
 		"LookupNS": {
-			callArgs:   []interface{}{ctx, "foo"},
+			callArgs:   []interface{}{mock.Anything, "foo"},
 			returnArgs: []interface{}{[]*net.NS{{Host: "bar"}}, nil},
-			call: func(t *testing.T, r Resolver, success bool) error {
+			call: func(ctx context.Context, t *testing.T, r Resolver, success bool) error {
 				records, err := r.LookupNS(ctx, "foo")
 				if success {
 					require.Equal(t, []*net.NS{{Host: "bar"}}, records)
@@ -135,9 +136,9 @@ func TestNewRetryLookup(t *testing.T) {
 			},
 		},
 		"LookupTXT": {
-			callArgs:   []interface{}{ctx, "foo"},
+			callArgs:   []interface{}{mock.Anything, "foo"},
 			returnArgs: []interface{}{[]string{"bar"}, nil},
-			call: func(t *testing.T, r Resolver, success bool) error {
+			call: func(ctx context.Context, t *testing.T, r Resolver, success bool) error {
 				records, err := r.LookupTXT(ctx, "foo")
 				if success {
 					require.Equal(t, []string{"bar"}, records)
@@ -146,9 +147,9 @@ func TestNewRetryLookup(t *testing.T) {
 			},
 		},
 		"LookupAddr": {
-			callArgs:   []interface{}{ctx, "foo"},
+			callArgs:   []interface{}{mock.Anything, "foo"},
 			returnArgs: []interface{}{[]string{"bar"}, nil},
-			call: func(t *testing.T, r Resolver, success bool) error {
+			call: func(ctx context.Context, t *testing.T, r Resolver, success bool) error {
 				names, err := r.LookupAddr(ctx, "foo")
 				if success {
 					require.Equal(t, []string{"bar"}, names)
@@ -164,7 +165,7 @@ func TestNewRetryLookup(t *testing.T) {
 				withRetry(t, func(m *mockResolver, r Resolver) {
 					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), temporaryError)...).Once()
 					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), permanentError)...).Once()
-					err := tt.call(t, r, false)
+					err := tt.call(ctx, t, r, false)
 					require.EqualError(t, err, "lookup foo: baz")
 				})
 			})
@@ -172,7 +173,7 @@ func TestNewRetryLookup(t *testing.T) {
 			t.Run("retry servfail", func(t *testing.T) {
 				withRetry(t, func(m *mockResolver, r Resolver) {
 					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), &net.DNSError{Name: "foo", Err: "server misbehaving", IsTemporary: true})...).Times(3)
-					err := tt.call(t, r, false)
+					err := tt.call(ctx, t, r, false)
 
 					var dnsError *net.DNSError
 					require.True(t, errors.As(err, &dnsError))
@@ -183,8 +184,19 @@ func TestNewRetryLookup(t *testing.T) {
 			t.Run("retry exhaustion", func(t *testing.T) {
 				withRetry(t, func(m *mockResolver, r Resolver) {
 					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), temporaryError)...).Times(3)
-					err := tt.call(t, r, false)
+					err := tt.call(ctx, t, r, false)
 					require.EqualError(t, err, "lookup foo: bar")
+				})
+			})
+
+			t.Run("canceled", func(t *testing.T) {
+				withRetry(t, func(m *mockResolver, r Resolver) {
+					ctx, cancel := context.WithCancel(ctx)
+					cancel()
+
+					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), context.Canceled)...).Once()
+					err := tt.call(ctx, t, r, false)
+					require.EqualError(t, err, "context canceled")
 				})
 			})
 
@@ -192,7 +204,7 @@ func TestNewRetryLookup(t *testing.T) {
 				withRetry(t, func(m *mockResolver, r Resolver) {
 					m.On(method, tt.callArgs...).Return(makeErrorArgs(len(tt.returnArgs), temporaryError)...).Once()
 					m.On(method, tt.callArgs...).Return(tt.returnArgs...).Once()
-					err := tt.call(t, r, true)
+					err := tt.call(ctx, t, r, true)
 					require.NoError(t, err)
 				})
 			})


### PR DESCRIPTION
Minor bugfix:

The retry resolver was already correctly not retrying lookups if the underlying resolver was returning a context error, but was failing to properly cancel the sleep.