### PR TITLE
Use errors.As to locate LogFields on error

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,6 +25,11 @@ func New(name string) Logger {
 	}
 }
 
+type loggableError interface {
+	error
+	Loggable
+}
+
 func ContextLog(ctx Valuer, err []error, entry *logrus.Entry) *logrus.Entry {
 	if entry == nil {
 		entry = logrus.NewEntry(logrus.StandardLogger())
@@ -56,8 +61,9 @@ func ContextLog(ctx Valuer, err []error, entry *logrus.Entry) *logrus.Entry {
 
 		// Check last, to allow LogFields to overwrite this package's behaviour.
 		// Do not recurse in error causes, the error itself should merge its causes' fields if desired.
-		if logFields, ok := err0.(interface{ LogFields() logrus.Fields }); ok {
-			entry = entry.WithFields(logFields.LogFields())
+		var loggable loggableError
+		if errors.As(err0, &loggable) {
+			entry = entry.WithFields(loggable.LogFields())
 		}
 	}
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -66,7 +66,8 @@ func TestNew_OptionalErr(t *testing.T) {
 	t.Run("err with fields", func(t *testing.T) {
 		logger := New("foo")
 		ctx := context.Background()
-		err := &logFieldsErr{"bad stuff", logrus.Fields{"foo": "bar", "baz": "qux"}}
+		cause := &logFieldsErr{"bad stuff", logrus.Fields{"foo": "bar", "baz": "qux"}}
+		err := errors.Wrap(cause, "cause")
 
 		entry := logger(ctx, err).WithField("a", "b")
 
@@ -76,6 +77,7 @@ func TestNew_OptionalErr(t *testing.T) {
 			"foo":       "bar",
 			"baz":       "qux",
 			"error":     err,
+			"cause":     cause,
 		}, entry.Data)
 	})
 


### PR DESCRIPTION
Follow up of #79

Without this, a wrapped error would not end up exposing its cause's LogFields.