### PR TITLE
Add a dialer resolver to target a custom nameserver

### DIFF
--- a/resolver/net_resolver.go
+++ b/resolver/net_resolver.go
@@ -1,12 +1,36 @@
 package resolver
 
 import (
+	"context"
+	"fmt"
 	"net"
+	"strings"
 )
+
+const defaultDNSPort = 53
 
 func NewNetResolver(resolver *net.Resolver) Resolver {
 	if resolver == nil {
 		return net.DefaultResolver
 	}
 	return resolver
+}
+
+// NewDialerNetResolver returns a net.Resolver hijacking with a specific net.Dialer or the default dialer,
+// but using a specific nameserver instead of the system's.
+func NewDialerNetResolver(dialer *net.Dialer, nameserver string) Resolver {
+	if dialer == nil {
+		dialer = &net.Dialer{}
+	}
+
+	if strings.ContainsRune(nameserver, ':') {
+		nameserver = fmt.Sprintf("%s:%d", nameserver, defaultDNSPort)
+	}
+
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, nameserver)
+		},
+	}
 }

--- a/resolver/net_resolver_test.go
+++ b/resolver/net_resolver_test.go
@@ -1,0 +1,26 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNetResolver(t *testing.T) {
+	t.Skip("only meant to ran manually")
+
+	r := NewNetResolver(nil)
+	ips, err := r.LookupHost(context.Background(), "shopify.com")
+	require.NoError(t, err)
+	require.NotEmpty(t, ips)
+}
+
+func TestNewDialerNetResolver(t *testing.T) {
+	t.Skip("only meant to ran manually")
+
+	r := NewDialerNetResolver(nil, "8.8.8.8")
+	ips, err := r.LookupHost(context.Background(), "shopify.com")
+	require.NoError(t, err)
+	require.NotEmpty(t, ips)
+}


### PR DESCRIPTION
Inspired from https://stackoverflow.com/a/59889883

This only supports one nameserver, but the signature could be expanded at some point to fallback on other nameservers if the first fails to connect.