### PR TITLE
Go back to upstream mux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bugsnag/bugsnag-go/v2 v2.1.1
 	github.com/bugsnag/panicwrap v1.3.4
 	github.com/google/pprof v0.0.0-20210804190019-f964ff605595
-	github.com/gorilla/mux v1.7.3
+	github.com/gorilla/mux v1.8.0
 	github.com/ianlancetaylor/demangle v0.0.0-20210724235854-665d3a6fe486 // indirect
 	github.com/imdario/mergo v0.3.12
 	github.com/leononame/clock v0.1.6
@@ -26,5 +26,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-replace github.com/gorilla/mux v1.6.3-0.20181031230737-63803a6dfc26 => github.com/lavoiesl/mux v1.6.3-0.20181031230737-63803a6dfc26

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPh
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/google/pprof v0.0.0-20210804190019-f964ff605595 h1:uNrRgpnKjTfxu4qHaZAAs3eKTYV1EzGF3dAykpnxgDE=
 github.com/google/pprof v0.0.0-20210804190019-f964ff605595/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
-github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20210724235854-665d3a6fe486 h1:GIP3QRFYn9u9T8P3efMXBODKE0Lhh+QrKZBc4EnzUpE=
 github.com/ianlancetaylor/demangle v0.0.0-20210724235854-665d3a6fe486/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=


### PR DESCRIPTION
Pick up fix from https://github.com/gorilla/mux/pull/422
Fixing the issue at https://github.com/gorilla/mux/issues/411

Which is the reason we had a fork in the first place: https://github.com/lavoiesl/mux/commit/63803a6dfc26397890ca526fd51c5518b5311b0e