### PR TITLE
Fix bugsnag tests to be compatible with Go1.16+

### DIFF
--- a/bugsnag/bugsnagger_test.go
+++ b/bugsnag/bugsnagger_test.go
@@ -1,8 +1,10 @@
 package bugsnag
 
 import (
+	"flag"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"runtime"
 	"strings"
@@ -34,6 +36,24 @@ func init() {
 		panic("unable to determine project dir")
 	}
 	projectDir = path.Dir(path.Dir(file))
+}
+
+func TestMain(m *testing.M) {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
+	// This test is incompatible with paniconexit0
+	panicFlag := flag.CommandLine.Lookup("test.paniconexit0")
+	if panicFlag != nil {
+		err := panicFlag.Value.Set("false")
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	code := m.Run()
+	os.Exit(code)
 }
 
 func TestSetup(t *testing.T) {


### PR DESCRIPTION
Always set `-test.paniconexit0=false`

That flag was added in 1.16 and even though it seems to be defaulting to false, it was being set as true somewhere.

Found while working on adding support for 1.16 in #102 