### PR TITLE
Change logrusbugsnag tests to look at events instead of sniffing json payload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/DataDog/datadog-go v3.4.0+incompatible
-	github.com/bitly/go-simplejson v0.5.0
+	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bugsnag/bugsnag-go v1.5.3
 	github.com/bugsnag/panicwrap v1.2.0


### PR DESCRIPTION
Removes dependency on simplejson and makes the test more robust by using bugsnag's API.

Trying to upgrade Go to 1.16 was breaking this test, the event was sometimes not appearing in the sniffing, not entirely sure why.

Found while working on adding support for 1.16 in #102