### PR TITLE
Include STATSD_DEFAULT_TAGS by default

### DIFF
--- a/bugsnag/with_class_test.go
+++ b/bugsnag/with_class_test.go
@@ -26,13 +26,13 @@ func TestWrappedWithErrorClass(t *testing.T) {
 func TestFormatErrorClass(t *testing.T) {
 	err := WithErrorClass(errors.New("test error"), "FOO")
 	formatted := fmt.Sprintf("%+v", err)
+	fmt.Println(formatted)
 	require.Contains(t, formatted, "FOO: test error")
 	require.Contains(t, formatted, "github.com/Shopify/goose/bugsnag.TestFormatErrorClass")
 	require.Contains(t, formatted, projectDir+"/bugsnag/with_class_test.go")
 	require.Contains(t, formatted, "testing.tRunner")
 	require.Contains(t, formatted, "src/testing/testing.go")
 	require.Contains(t, formatted, "runtime.goexit")
-	require.Contains(t, formatted, "src/runtime/asm_amd64.s")
 }
 
 func TestWrapf(t *testing.T) {

--- a/statsd/datadog_backend.go
+++ b/statsd/datadog_backend.go
@@ -14,13 +14,15 @@ import (
 // It should end with a period to separate it from the metric name.
 //
 // `tags` is a set of tags that will be included with every metric submitted.
+// STATSD_DEFAULT_TAGS env variable will be read automatically and added to default tags.
 func NewDatadogBackend(endpoint, namespace string, tags []string) (Backend, error) {
 	client, err := statsd.New(endpoint)
 	if err != nil {
 		return nil, err
 	}
 	client.Namespace = namespace
-	client.Tags = tags
+	defaultTags := append(defaultTagsFromEnv(), tags...)
+	client.Tags = defaultTags
 	return &datadogBackend{
 		client: client,
 	}, nil

--- a/statsd/default_tags.go
+++ b/statsd/default_tags.go
@@ -1,0 +1,18 @@
+package statsd
+
+import (
+	"os"
+	"strings"
+)
+
+const StatsdDefaultTags = "STATSD_DEFAULT_TAGS"
+
+func defaultTagsFromEnv() []string {
+	statsdTags, found := os.LookupEnv(StatsdDefaultTags)
+	if !found || statsdTags == "" {
+		return nil
+	}
+
+	const defaultSep = ","
+	return strings.Split(statsdTags, defaultSep)
+}

--- a/statsd/default_tags_test.go
+++ b/statsd/default_tags_test.go
@@ -1,0 +1,53 @@
+package statsd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_defaultTagsFromEnv(t *testing.T) {
+	oldValueTags := os.Getenv(StatsdDefaultTags)
+	defer restoreStatsdTagsValue()(oldValueTags)
+
+	tt := []struct {
+		name        string
+		envVarValue string
+		wantTags    []string
+	}{
+		{
+			name:        "when not set, returns nil",
+			envVarValue: "",
+			wantTags:    nil,
+		},
+		{
+			name:        "when no comma, returns one tag",
+			envVarValue: "foo:bar",
+			wantTags:    []string{"foo:bar"},
+		},
+		{
+			name:        "when there is comma, break into multiple tags",
+			envVarValue: "foo:bar,kube_namespace:production-unrestricted-k9asf9",
+			wantTags:    []string{"foo:bar", "kube_namespace:production-unrestricted-k9asf9"},
+		},
+	}
+
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			err := os.Setenv(StatsdDefaultTags, test.envVarValue)
+			require.NoError(t, err)
+
+			gotTags := defaultTagsFromEnv()
+
+			assert.EqualValues(t, test.wantTags, gotTags)
+		})
+	}
+}
+
+func restoreStatsdTagsValue() func(oldValue string) {
+	return func(oldValue string) {
+		_ = os.Setenv("STATSD_DEFAULT_TAGS", oldValue)
+	}
+}

--- a/statsd/log_backend.go
+++ b/statsd/log_backend.go
@@ -12,9 +12,11 @@ import (
 // namespace is a global namespace to apply to every metric emitted.
 // tags is a global set of tags that will be added to every metric emitted.
 func NewLogBackend(namespace string, tags []string) Backend {
+	defaultTags := append(defaultTagsFromEnv(), tags...)
+
 	lb := &logBackend{
 		namespace: namespace,
-		tags:      tags,
+		tags:      defaultTags,
 	}
 	return NewForwardingBackend(lb.log)
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -47,6 +47,7 @@ func SetBackend(b Backend) {
 var ErrUnknownBackend = fmt.Errorf("unknown statsd backend type")
 
 // NewBackend returns the appropriate Backend for the given implementation and host.
+// STATSD_DEFAULT_TAGS env variable will be read automatically and added to default tags.
 func NewBackend(impl, addr, prefix string, tags ...string) (Backend, error) {
 	var err error
 	var b Backend


### PR DESCRIPTION
recent infrastructure changes caused that datadog-go stats is unable to get some pods metrics like kube-namespace, etc, due to the statsd agent URL change.

This add the ability to read the default tags and append the tags to the backens.

this PR basically copy/paste what @pedro-stanaka did here https://github.com/Shopify/imagery4/pull/1083

Co-authored-by: Diego Alvarez <diego.alvarez@shopify.com>
Co-authored-by: Pedro Tanaka <pedro.tanaka@shopify.com>