### PR TITLE
statsd: add Flush() to datadogBackend

### DIFF
--- a/statsd/datadog_backend.go
+++ b/statsd/datadog_backend.go
@@ -55,3 +55,7 @@ func (b *datadogBackend) Set(ctx context.Context, name string, value string, tag
 func (b *datadogBackend) Timing(ctx context.Context, name string, value time.Duration, tags []string, rate float64) error {
 	return b.client.Timing(name, value, tags, rate)
 }
+
+func (b *datadogBackend) Flush() error {
+	return b.client.Flush()
+}


### PR DESCRIPTION
_Remade this PR from #141 to re-trigger CLA_

This PR adds a public method to flush any remaining metrics manually (rather than waiting for the flush interval), by calling the [Flush() method](https://pkg.go.dev/github.com/DataDog/datadog-go/v5/statsd#Client.Flush) on the dogstatsd client.

This is helpful in the case of recording a metric right before terminating the program. In this case, the metric will not get submitted to datadog - the only workaround being putting a `sleep` in place for at least as long as the flush interval.

With this, one can call `Flush()` before the program terminates to make sure any remaining metrics are submitted to Datadog.