### PR TITLE
Update RequestMetricsMiddleware to accept an observer

### DIFF
--- a/srvutil/metrics.go
+++ b/srvutil/metrics.go
@@ -1,79 +1,9 @@
 package srvutil
 
 import (
-	"bufio"
-	"bytes"
-	"net"
 	"net/http"
 	"time"
 )
-
-type BodyLogPredicateFunc func(statusCode int) bool
-
-func LogErrorBody(statusCode int) bool {
-	return statusCode >= 400
-}
-
-type HTTPRecorder interface {
-	http.ResponseWriter
-	StatusCode() int
-	ResponseBody() *string
-}
-
-type httpRecorder struct {
-	http.ResponseWriter
-	statusCode int
-
-	bodyLogPredicate BodyLogPredicateFunc
-	body             bytes.Buffer
-}
-
-func (w *httpRecorder) WriteHeader(statusCode int) {
-	w.statusCode = statusCode
-	w.ResponseWriter.WriteHeader(statusCode)
-}
-
-func (w *httpRecorder) Write(data []byte) (int, error) {
-	// If WriteHeader is never called, treat as 200, which is the underlying behaviour
-	if w.statusCode == 0 {
-		w.statusCode = http.StatusOK
-	}
-
-	if w.bodyLogPredicate != nil && w.bodyLogPredicate(w.statusCode) {
-		w.body.Write(data)
-	}
-
-	return w.ResponseWriter.Write(data)
-}
-
-func (w *httpRecorder) StatusCode() int {
-	return w.statusCode
-}
-
-func (w *httpRecorder) ResponseBody() *string {
-	if w.body.Len() == 0 {
-		return nil
-	}
-	s := w.body.String()
-	return &s
-}
-
-type hijackableRecorder struct {
-	httpRecorder
-}
-
-// Hijack implements the http.Hijacker interface, to allow for e.g. WebSockets.
-func (w *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return w.httpRecorder.ResponseWriter.(http.Hijacker).Hijack()
-}
-
-func newHTTPRecorder(w http.ResponseWriter, bodyLogPredicate BodyLogPredicateFunc) HTTPRecorder {
-	recorder := httpRecorder{ResponseWriter: w, bodyLogPredicate: bodyLogPredicate}
-	if _, ok := w.(http.Hijacker); ok {
-		return &hijackableRecorder{recorder}
-	}
-	return &recorder
-}
 
 type RequestMetricsMiddlewareConfig struct {
 	BodyLogPredicate BodyLogPredicateFunc

--- a/srvutil/metrics_observer.go
+++ b/srvutil/metrics_observer.go
@@ -1,0 +1,47 @@
+package srvutil
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Shopify/goose/metrics"
+	"github.com/Shopify/goose/redact"
+	"github.com/Shopify/goose/statsd"
+)
+
+type RequestObserver interface {
+	BeforeRequest(*http.Request)
+	AfterRequest(*http.Request, HTTPRecorder, time.Duration)
+}
+
+type DefaultRequestObserver struct{}
+
+func (o *DefaultRequestObserver) BeforeRequest(r *http.Request) {
+	ctx := r.Context()
+
+	log(ctx).
+		WithField("method", r.Method).
+		WithField("headers", redact.Headers(r.Header)).
+		Info("http request")
+}
+
+func (o *DefaultRequestObserver) AfterRequest(r *http.Request, recorder HTTPRecorder, requestDuration time.Duration) {
+	ctx := r.Context()
+
+	ctx = statsd.WithTagLogFields(ctx, statsd.Tags{
+		"statusCode":  recorder.StatusCode(),
+		"statusClass": fmt.Sprintf("%dxx", recorder.StatusCode()/100), // 2xx, 5xx, etc.
+	})
+
+	metrics.HTTPRequest.Duration(ctx, requestDuration)
+
+	logger := log(ctx).
+		WithField("headers", redact.Headers(recorder.Header()))
+
+	if body := recorder.ResponseBody(); body != nil {
+		logger = logger.WithField("responseBody", *body)
+	}
+
+	logger.Info("http response")
+}

--- a/srvutil/metrics_test.go
+++ b/srvutil/metrics_test.go
@@ -75,7 +75,7 @@ func TestRequestMetricsMiddleware(t *testing.T) {
 	assert.Equal(t, "hello world", string(body))
 
 	assert.NotNil(t, recordedTags, "should have recorded a %s tag", metrics.HTTPRequest.Name)
-	assert.Equal(t, []string{"route:/hello/@name", "statusClass:2xx", "statusCode:200", "success:true"}, recordedTags)
+	assert.Equal(t, []string{"route:/hello/@name", "statusClass:2xx", "statusCode:200"}, recordedTags)
 
 	output := strings.ToLower(logging.String())
 	assert.Contains(t, output, "statusclass=2xx")

--- a/srvutil/recorder.go
+++ b/srvutil/recorder.go
@@ -1,0 +1,75 @@
+package srvutil
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"net/http"
+)
+
+type BodyLogPredicateFunc func(statusCode int) bool
+
+func LogErrorBody(statusCode int) bool {
+	return statusCode >= 400
+}
+
+type HTTPRecorder interface {
+	http.ResponseWriter
+	StatusCode() int
+	ResponseBody() *string
+}
+
+type httpRecorder struct {
+	http.ResponseWriter
+	statusCode int
+
+	bodyLogPredicate BodyLogPredicateFunc
+	body             bytes.Buffer
+}
+
+func (w *httpRecorder) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *httpRecorder) Write(data []byte) (int, error) {
+	// If WriteHeader is never called, treat as 200, which is the underlying behaviour
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
+
+	if w.bodyLogPredicate != nil && w.bodyLogPredicate(w.statusCode) {
+		w.body.Write(data)
+	}
+
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *httpRecorder) StatusCode() int {
+	return w.statusCode
+}
+
+func (w *httpRecorder) ResponseBody() *string {
+	if w.body.Len() == 0 {
+		return nil
+	}
+	s := w.body.String()
+	return &s
+}
+
+type hijackableRecorder struct {
+	httpRecorder
+}
+
+// Hijack implements the http.Hijacker interface, to allow for e.g. WebSockets.
+func (w *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.httpRecorder.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+func newHTTPRecorder(w http.ResponseWriter, bodyLogPredicate BodyLogPredicateFunc) HTTPRecorder {
+	recorder := httpRecorder{ResponseWriter: w, bodyLogPredicate: bodyLogPredicate}
+	if _, ok := w.(http.Hijacker); ok {
+		return &hijackableRecorder{recorder}
+	}
+	return &recorder
+}


### PR DESCRIPTION
There is no way to change/extend how RequestMetricsMiddleware is reporting the data collected.

This PR is changing the middleware to only record information and delegate the reporting to an observer.

The default behaviour of the middleware is unchanged: the default observer is logging and reporting metrics like previously.