### PR TITLE
v2 release WIP

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3.1.0
 
+    - name: Setup go
+      uses: actions/setup-go@v3.3.0
+      with:
+        go-version: 1.20.x
+
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.2.0
       with:
@@ -34,7 +39,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3.3.0
       with:
-        go-version: 1.15.x
+        go-version: 1.20.x
 
     - name: Cache
       uses: actions/cache@v3.0.10
@@ -57,9 +62,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - 1.17.x
-        - 1.18.x
-        - 1.19.x
+        - 1.20.x
 
     steps:
     - name: Checkout

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.2.0
       with:
-        version: v1.49.0
+        version: v1.51.1
 
   mod-tidy:
     name: Go Mod Tidy

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,15 +19,14 @@ linters:
     - gocritic
     - gofmt
     - goimports
-    - golint
     - gosec
     - govet
     - lll
-    - maligned
     - megacheck
     - misspell
     - nakedret
     - prealloc
+    - revive
     - stylecheck
     - unconvert
     - unparam

--- a/bin/style
+++ b/bin/style
@@ -1,62 +1,59 @@
-#!/usr/bin/env ruby
+#!/bin/sh
 
-require 'fileutils'
-require 'open3'
-require 'open-uri'
+# This script is intentionally written to be POSIX compliant to be as portable as possible
 
-class Style
-  class << self
-    INSTALLER_URL = 'https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh'
-    EXECUTABLE = 'golangci-lint'
-    VERSION = '1.49.0'
-    VERSION_TAG = "v#{VERSION}"
+set -e
 
-    def call
-      install unless up_to_date?
-      run(*ARGV)
-    end
+VERSION="1.51.1"
+VERSION_TAG="v${VERSION}"
 
-    private
+INSTALLER_URL="github.com/golangci/golangci-lint/cmd/golangci-lint"
+EXECUTABLE="$(basename "${INSTALLER_URL}")"
 
-    def install_path
-      gopath = ENV.fetch('GOPATH', ENV.fetch('HOME')).split(':').first
-      File.join(gopath, 'bin')
-    end
+INSTALL_PATH="${HOME}/.local/share/${EXECUTABLE}/${VERSION}"
+EXECUTABLE_PATH="${INSTALL_PATH}/${EXECUTABLE}" # e.g. $HOME/.local/share/golangci/1.32.0/golangci-lint
 
-    def bin_path
-      File.join(install_path, EXECUTABLE)
-    end
+GOPATH="${GOPATH:-${HOME}}"
+GOPATH_PRIMARY="${GOPATH%%:*}" # Delete :* from the end, yielding the first path
+BIN_INSTALL_PATH="${GOPATH_PRIMARY}/bin"
+BIN_EXECUTABLE_PATH="${BIN_INSTALL_PATH}/${EXECUTABLE}" # e.g. $HOME/bin/golangci-lint
 
-    def exist?
-      File.executable?(bin_path)
-    end
+installed() {
+    [ -x "${EXECUTABLE_PATH}" ]
+}
 
-    def up_to_date?
-      return false unless exist?
-      out, stat = Open3.capture2(bin_path, '--version')
-      raise("Unable to check version of #{bin_path}") unless stat.success?
-      out.match(/\b#{VERSION}\b/)
-    end
+install() {
+    echo "Installing ${EXECUTABLE} version ${VERSION}" >&2
 
-    def install
-      puts "Installing #{EXECUTABLE}..."
+    mkdir -p "${INSTALL_PATH}"
+    GOBIN="${INSTALL_PATH}" go install "${INSTALLER_URL}@${VERSION_TAG}"
+}
 
-      open(INSTALLER_URL) do |installer|
-        Open3.popen2('sh', '-s', '--', '-b', install_path, VERSION_TAG) do |stdin, out, stat|
-          IO.copy_stream(installer, stdin)
-          stdin.close
-          print out.read
+linked() {
+    [ -L "${BIN_EXECUTABLE_PATH}" ] && [ "$(readlink "${BIN_EXECUTABLE_PATH}")" = "${EXECUTABLE_PATH}" ]
+}
 
-          raise("failed to install #{EXECUTABLE} #{VERSION_TAG}") unless stat.value.success?
-        end
-      end
-    end
+link() {
+    mkdir -p "${BIN_INSTALL_PATH}"
+    rm -fv "${BIN_EXECUTABLE_PATH}"
+    ln -sfv "${EXECUTABLE_PATH}" "${BIN_EXECUTABLE_PATH}"
+}
 
-    def run(*argv)
-      config = ENV.fetch('GOLANGCI_CONFIG', '.golangci.yml')
-      exec(bin_path, 'run', '--config', config, *argv)
-    end
-  end
-end
-
-__FILE__ == $PROGRAM_NAME and Style.call
+case "$1" in
+    "--installed")
+        installed
+        ;;
+    "--install")
+        installed || install
+        ;;
+    "--linked")
+        installed && linked
+        ;;
+    "--link")
+        (installed || install) && (linked || link)
+        ;;
+    *)
+        installed || install
+        exec "${EXECUTABLE_PATH}" "$@"
+        ;;
+esac

--- a/bugsnag/bugsnagger.go
+++ b/bugsnag/bugsnagger.go
@@ -214,7 +214,7 @@ func (snagger *bugsnagger) Setup(apiKey string, commit string, env string, packa
 	// Add the bugsnag package and it's folder location on disk to bugsnag's ProjectPackages.
 	// This will ensure that Notify calls from bugsnagger.go will always share the same file name
 	// and will retain grouping across Shopify/goose dependency upgrades.
-	packages = append(packages, "main*", "github.com/Shopify/goose/bugsnag")
+	packages = append(packages, "main*", "github.com/Shopify/goose/v2/bugsnag")
 	if _, file, _, ok := runtime.Caller(0); ok {
 		gooseMod := strings.TrimSuffix(file, "bugsnag/bugsnagger.go")
 		packages = append(packages, gooseMod+"*")

--- a/bugsnag/bugsnagger_test.go
+++ b/bugsnag/bugsnagger_test.go
@@ -70,7 +70,7 @@ func TestSetup(t *testing.T) {
 	require.Equal(t, env, bugsnaggo.Config.ReleaseStage)
 	require.Equal(t, pack, bugsnaggo.Config.ProjectPackages[0])
 	require.Equal(t, "main*", bugsnaggo.Config.ProjectPackages[1])
-	require.Equal(t, "github.com/Shopify/goose/bugsnag", bugsnaggo.Config.ProjectPackages[2])
+	require.Equal(t, "github.com/Shopify/goose/v2/bugsnag", bugsnaggo.Config.ProjectPackages[2])
 	require.True(t, strings.Contains(bugsnaggo.Config.ProjectPackages[3], projectDir+"/*"))
 	require.True(t, bugsnaggo.Config.Synchronous)
 }

--- a/bugsnag/with_class_test.go
+++ b/bugsnag/with_class_test.go
@@ -27,7 +27,7 @@ func TestFormatErrorClass(t *testing.T) {
 	err := WithErrorClass(errors.New("test error"), "FOO")
 	formatted := fmt.Sprintf("%+v", err)
 	require.Contains(t, formatted, "FOO: test error")
-	require.Contains(t, formatted, "github.com/Shopify/goose/bugsnag.TestFormatErrorClass")
+	require.Contains(t, formatted, "github.com/Shopify/goose/v2/bugsnag.TestFormatErrorClass")
 	require.Contains(t, formatted, projectDir+"/bugsnag/with_class_test.go")
 	require.Contains(t, formatted, "testing.tRunner")
 	require.Contains(t, formatted, "src/testing/testing.go")

--- a/concurrency/limiter.go
+++ b/concurrency/limiter.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/sync/semaphore"
 
-	"github.com/Shopify/goose/statsd"
+	"github.com/Shopify/goose/v2/statsd"
 )
 
 const (

--- a/concurrency/throttler.go
+++ b/concurrency/throttler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Shopify/goose/timetracker"
+	"github.com/Shopify/goose/v2/timetracker"
 )
 
 func NewThrottler(limiter Limiter, tracker timetracker.Tracker, waitTimeout time.Duration) Throttler {

--- a/concurrency/throttler_test.go
+++ b/concurrency/throttler_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/Shopify/goose/timetracker"
+	"github.com/Shopify/goose/v2/timetracker"
 )
 
 func TestThrottler(t *testing.T) {

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ name: goose
 
 up:
   - go:
-      version: "1.19.2"
+      version: "1.20"
       modules: true
 
 commands:

--- a/dev.yml
+++ b/dev.yml
@@ -11,7 +11,7 @@ commands:
     godoc -http=:6060
   test: go test -race ./...
   style:
-    run: bin/style
-    desc: Static verification using gometalinter or autofix issues when possible.
+    run: bin/style run
+    desc: Static verification using golangci or autofix issues when possible.
     syntax:
       optional: --fix

--- a/genmain/component.go
+++ b/genmain/component.go
@@ -1,6 +1,6 @@
 package genmain
 
-import "github.com/Shopify/goose/safely"
+import "github.com/Shopify/goose/v2/safely"
 
 // Component is used to represent various "components". At a high level, main()
 // essentially cobbles together a few components whose lifecycles are managed

--- a/genmain/genmain.go
+++ b/genmain/genmain.go
@@ -14,10 +14,10 @@ import (
 
 	"gopkg.in/tomb.v2"
 
-	"github.com/Shopify/goose/logger"
-	"github.com/Shopify/goose/metrics"
-	"github.com/Shopify/goose/safely"
-	"github.com/Shopify/goose/statsd"
+	"github.com/Shopify/goose/v2/logger"
+	"github.com/Shopify/goose/v2/metrics"
+	"github.com/Shopify/goose/v2/safely"
+	"github.com/Shopify/goose/v2/statsd"
 )
 
 var log = logger.New("genmain")

--- a/genmain/genmain_test.go
+++ b/genmain/genmain_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/tomb.v2"
 
-	"github.com/Shopify/goose/genmain"
+	"github.com/Shopify/goose/v2/genmain"
 )
 
 type testComponent struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Shopify/goose
+module github.com/Shopify/goose/v2
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,13 @@
 module github.com/Shopify/goose
 
-go 1.15
+go 1.20
 
 require (
 	github.com/DataDog/datadog-go v4.8.1+incompatible
-	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/bugsnag/bugsnag-go/v2 v2.1.1
 	github.com/bugsnag/panicwrap v1.3.4
 	github.com/google/pprof v0.0.0-20210804190019-f964ff605595
 	github.com/gorilla/mux v1.8.0
-	github.com/ianlancetaylor/demangle v0.0.0-20210724235854-665d3a6fe486 // indirect
 	github.com/imdario/mergo v0.3.12
 	github.com/leononame/clock v0.1.6
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
@@ -18,9 +16,20 @@ require (
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
+)
+
+require (
+	github.com/Microsoft/go-winio v0.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gofrs/uuid v4.0.0+incompatible // indirect
+	github.com/ianlancetaylor/demangle v0.0.0-20210724235854-665d3a6fe486 // indirect
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,6 @@ github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXG
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bugsnag/bugsnag-go/v2 v2.1.1 h1:/X6xB3DvfMCNOSopEvGkOpDSk0iTq4yBSp7SkiV7nM8=
 github.com/bugsnag/bugsnag-go/v2 v2.1.1/go.mod h1:XEgTxTSo37lM/jpzZY9a8FJgJCqZMEagthLA6TSDl+o=
@@ -62,16 +61,11 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cO
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 h1:c8PlLMqBbOHoqtjteWm5/kbe6rNY2pbRfbIMVnepueo=
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/logger/loggable.go
+++ b/logger/loggable.go
@@ -7,10 +7,10 @@ import (
 )
 
 // This create a private key-space in the Context, meaning that only this package can get or set "contextKey" types
-type contextKey int
+type contextKey struct{}
 
-const (
-	logFieldsKey contextKey = iota
+var (
+	logFieldsKey = contextKey{}
 )
 
 type Loggable interface {

--- a/logger/loggable_test.go
+++ b/logger/loggable_test.go
@@ -64,7 +64,7 @@ func ExampleWatchingLoggable() {
 func TestEmptyContext(t *testing.T) {
 	ctx := context.Background()
 	// Using a basic type on purpose, disable linter
-	ctx = context.WithValue(ctx, "a", "b") //nolint:golint,staticcheck
+	ctx = context.WithValue(ctx, "a", "b") //nolint:revive,staticcheck
 	// Not showing up in logs
 	checkData(ctx, t, logrus.Fields{"component": "testing"})
 }
@@ -113,19 +113,6 @@ func TestWithField(t *testing.T) {
 	checkData(ctx, t, logrus.Fields{
 		"a": "b",
 		"c": "e",
-	})
-}
-
-func TestLoggableKeyClash(t *testing.T) {
-	ctx := context.Background()
-	ctx = WithField(ctx, "a", "b")
-
-	// logFieldsKey is an int declared as a contextKey, so trying to set an int shouldn't override the contextKey
-	// Using a basic type on purpose, disable linter
-	ctx = context.WithValue(ctx, int(logFieldsKey), "foo") //nolint:golint,staticcheck
-
-	checkData(ctx, t, logrus.Fields{
-		"a": "b",
 	})
 }
 

--- a/logrusbugsnag/bugsnag_test.go
+++ b/logrusbugsnag/bugsnag_test.go
@@ -3,7 +3,7 @@ package logrusbugsnag
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"testing"
@@ -25,7 +25,7 @@ type nilRoundTripper struct{}
 
 func (rt *nilRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: http.StatusOK,
 	}, nil
 }
@@ -33,7 +33,7 @@ func (rt *nilRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 func setup(record bool) {
 	testOnce.Do(func() {
 		l := logrus.New()
-		l.Out = ioutil.Discard
+		l.Out = io.Discard
 
 		bugsnag.Configure(bugsnag.Configuration{
 			APIKey: testAPIKey,
@@ -57,7 +57,7 @@ func BenchmarkHook_Fire(b *testing.B) {
 	setup(false)
 
 	l := logrus.New()
-	l.Out = ioutil.Discard
+	l.Out = io.Discard
 
 	hook, err := NewBugsnagHook(nil)
 	assert.NoError(b, err)
@@ -89,7 +89,7 @@ func TestNewBugsnagHook(t *testing.T) {
 	setup(true)
 
 	l := logrus.New()
-	l.Out = ioutil.Discard
+	l.Out = io.Discard
 
 	hook, err := NewBugsnagHook(nil)
 	assert.NoError(t, err)

--- a/logrussplunk/splunk.go
+++ b/logrussplunk/splunk.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
 
-	"github.com/Shopify/goose/logger"
+	"github.com/Shopify/goose/v2/logger"
 )
 
 type jsonMap map[string]interface{}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"github.com/Shopify/goose/statsd"
+	"github.com/Shopify/goose/v2/statsd"
 )
 
 // Note that statsd's default backend is the nullBackend, which doesn't do anything.

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 
-	"github.com/Shopify/goose/logger"
+	"github.com/Shopify/goose/v2/logger"
 )
 
 var log = logger.New("profiler")

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -1,6 +1,6 @@
 package profiler_test
 
-import "github.com/Shopify/goose/profiler"
+import "github.com/Shopify/goose/v2/profiler"
 
 func ExampleNewProfiler() {
 	cpuFile := "cpu.prof"

--- a/profiler/servlet.go
+++ b/profiler/servlet.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/Shopify/goose/srvutil"
+	"github.com/Shopify/goose/v2/srvutil"
 )
 
 // NewServlet returns a Servlet which can serve pprof requests

--- a/profiler/ui.go
+++ b/profiler/ui.go
@@ -3,7 +3,6 @@ package profiler
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	httppprof "net/http/pprof"
@@ -19,7 +18,7 @@ func pprofUIHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vars := mux.Vars(r)
 
-	f, err := ioutil.TempFile("", "pprof.*.pb")
+	f, err := os.CreateTemp("", "pprof.*.pb")
 	if err != nil {
 		log(ctx, err).Error("error creating temporary file")
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/resolver/metric_resolver.go
+++ b/resolver/metric_resolver.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net"
 
-	"github.com/Shopify/goose/statsd"
+	"github.com/Shopify/goose/v2/statsd"
 )
 
 type metricResolver struct {

--- a/resolver/shuffle_resolver.go
+++ b/resolver/shuffle_resolver.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"net"
 
-	"github.com/Shopify/goose/random"
+	"github.com/Shopify/goose/v2/random"
 )
 
 type shuffleResolver struct {

--- a/resolver/shuffle_resolver_test.go
+++ b/resolver/shuffle_resolver_test.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/Shopify/goose/random"
+	"github.com/Shopify/goose/v2/random"
 
 	"github.com/stretchr/testify/require"
 )

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/Shopify/goose/logger"
-	"github.com/Shopify/goose/statsd"
+	"github.com/Shopify/goose/v2/logger"
+	"github.com/Shopify/goose/v2/statsd"
 )
 
 var log = logger.New("shell")

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ func ExampleSupervisor_Wait() {
 	stdin.Write([]byte("foo"))
 	stdin.Close()
 
-	output, _ := ioutil.ReadAll(stdout)
+	output, _ := io.ReadAll(stdout)
 
 	// Must call Wait _after_ interacting with pipes
 	cmd.Wait()
@@ -144,7 +143,7 @@ func TestCommandRunPipe(t *testing.T) {
 	assert.NotEqual(t, 0, c.Process.Pid) // But the process exists
 
 	// Calling ReadAll will wait for the pipe to close, so all the output is there.
-	output, err := ioutil.ReadAll(pipe)
+	output, err := io.ReadAll(pipe)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("foo"), output)
 
@@ -174,7 +173,7 @@ func TestCommandRunWaitPipeFails(t *testing.T) {
 	assert.True(t, c.ProcessState.Exited())
 
 	// Calling ReadAll will wait for the pipe to close, so all the output is there.
-	_, err = ioutil.ReadAll(pipe)
+	_, err = io.ReadAll(pipe)
 	assert.Error(t, err, "read |0: file already closed")
 }
 

--- a/shell/supervisor.go
+++ b/shell/supervisor.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Shopify/goose/logger"
-	"github.com/Shopify/goose/metrics"
+	"github.com/Shopify/goose/v2/logger"
+	"github.com/Shopify/goose/v2/metrics"
 )
 
 type Supervisor interface {

--- a/srvutil/env_var_middleware_test.go
+++ b/srvutil/env_var_middleware_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Shopify/goose/srvutil"
+	"github.com/Shopify/goose/v2/srvutil"
 )
 
 func ExampleEnvVarHeaderMiddleware() {

--- a/srvutil/metrics_observer.go
+++ b/srvutil/metrics_observer.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Shopify/goose/metrics"
-	"github.com/Shopify/goose/redact"
-	"github.com/Shopify/goose/statsd"
+	"github.com/Shopify/goose/v2/metrics"
+	"github.com/Shopify/goose/v2/redact"
+	"github.com/Shopify/goose/v2/statsd"
 )
 
 type RequestObserver interface {

--- a/srvutil/metrics_test.go
+++ b/srvutil/metrics_test.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -70,7 +70,7 @@ func TestRequestMetricsMiddleware(t *testing.T) {
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "hello world", string(body))
 

--- a/srvutil/metrics_test.go
+++ b/srvutil/metrics_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/tomb.v2"
 
-	"github.com/Shopify/goose/metrics"
-	"github.com/Shopify/goose/safely"
-	"github.com/Shopify/goose/statsd"
+	"github.com/Shopify/goose/v2/metrics"
+	"github.com/Shopify/goose/v2/safely"
+	"github.com/Shopify/goose/v2/statsd"
 )
 
 func TestRequestMetricsMiddleware(t *testing.T) {

--- a/srvutil/real_ip_test.go
+++ b/srvutil/real_ip_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Shopify/goose/srvutil"
+	"github.com/Shopify/goose/v2/srvutil"
 )
 
 func ExampleRealIPMiddleware() {

--- a/srvutil/request.go
+++ b/srvutil/request.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
-	"github.com/Shopify/goose/logger"
-	"github.com/Shopify/goose/statsd"
+	"github.com/Shopify/goose/v2/logger"
+	"github.com/Shopify/goose/v2/statsd"
 )
 
 var log = logger.New("srvutil")

--- a/srvutil/request_test.go
+++ b/srvutil/request_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Shopify/goose/logger"
+	"github.com/Shopify/goose/v2/logger"
 )
 
 func TestBuildContext(t *testing.T) {

--- a/srvutil/security_test.go
+++ b/srvutil/security_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Shopify/goose/srvutil"
+	"github.com/Shopify/goose/v2/srvutil"
 )
 
 func TestSecurityHeaderMiddleware(t *testing.T) {

--- a/srvutil/server.go
+++ b/srvutil/server.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gorilla/mux"
 	"gopkg.in/tomb.v2"
 
-	"github.com/Shopify/goose/logger"
-	"github.com/Shopify/goose/safely"
+	"github.com/Shopify/goose/v2/logger"
+	"github.com/Shopify/goose/v2/safely"
 )
 
 const (

--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/tomb.v2"
 
-	"github.com/Shopify/goose/safely"
-	"github.com/Shopify/goose/syncio"
+	"github.com/Shopify/goose/v2/safely"
+	"github.com/Shopify/goose/v2/syncio"
 )
 
 func ExampleNewServer() {

--- a/srvutil/server_test.go
+++ b/srvutil/server_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -73,7 +72,7 @@ func TestNewServer(t *testing.T) {
 	res, err := http.Get(u)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "great success", string(body))
 
@@ -136,7 +135,7 @@ func TestNewServerFromFactory(t *testing.T) {
 	res, err := http.Get(u)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "great success", string(body))
 
@@ -214,7 +213,7 @@ func TestStoppableKeepaliveListener_Accept(t *testing.T) {
 		res, err := http.Get(u) // This will block on tb.Dying()
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, "great success", string(body))
 		close(done)

--- a/srvutil/servlet_test.go
+++ b/srvutil/servlet_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/tomb.v2"
 
-	"github.com/Shopify/goose/safely"
+	"github.com/Shopify/goose/v2/safely"
 )
 
 type dbConn interface {

--- a/statetracker/tracker.go
+++ b/statetracker/tracker.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Shopify/goose/logger"
+	"github.com/Shopify/goose/v2/logger"
 )
 
 var log = logger.New("stateTracker")

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Shopify/goose/logger"
+	"github.com/Shopify/goose/v2/logger"
 )
 
 var log = logger.New("statsd")

--- a/statsd/taggable.go
+++ b/statsd/taggable.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/Shopify/goose/logger"
+	"github.com/Shopify/goose/v2/logger"
 )
 
 // This create a private key-space in the Context, meaning that only this package can get or set "contextKey" types

--- a/statsd/taggable.go
+++ b/statsd/taggable.go
@@ -9,10 +9,10 @@ import (
 )
 
 // This create a private key-space in the Context, meaning that only this package can get or set "contextKey" types
-type contextKey int
+type contextKey struct{}
 
-const (
-	tagsKey contextKey = iota
+var (
+	tagsKey = contextKey{}
 )
 
 type Tags map[string]interface{}

--- a/statsd/taggable_test.go
+++ b/statsd/taggable_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Shopify/goose/logger"
+	"github.com/Shopify/goose/v2/logger"
 )
 
 var exampleBackend = NewForwardingBackend(func(_ context.Context, mType string, name string, value interface{}, tags []string, _ float64) error {

--- a/statsd/taggable_test.go
+++ b/statsd/taggable_test.go
@@ -91,7 +91,7 @@ func ExampleSelectKeys() {
 func TestEmptyContext(t *testing.T) {
 	ctx := context.Background()
 	// Using a basic type on purpose, disable linter
-	ctx = context.WithValue(ctx, "a", "b") //nolint:golint,staticcheck
+	ctx = context.WithValue(ctx, "a", "b") //nolint:revive,staticcheck
 	// Not showing up in tags
 	assert.Empty(t, getStatsTags(ctx))
 }
@@ -106,19 +106,6 @@ func TestWithTags(t *testing.T) {
 		"a:e",
 		"c:d",
 		"f:g",
-	}, getStatsTags(ctx))
-}
-
-func TestWithTags_keyClash(t *testing.T) {
-	ctx := context.Background()
-	ctx = WithTags(ctx, Tags{"a": "b"})
-
-	// tagsKey is an int declared as a contextKey, so trying to set an int shouldn't override the contextKey
-	// Using a basic type on purpose, disable linter
-	ctx = context.WithValue(ctx, int(tagsKey), "foo") //nolint:golint,staticcheck
-
-	assert.Equal(t, []string{
-		"a:b",
 	}, getStatsTags(ctx))
 }
 

--- a/statsd/timer_test.go
+++ b/statsd/timer_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	"github.com/Shopify/goose/statsd/mocks"
+	"github.com/Shopify/goose/v2/statsd/mocks"
 )
 
 func TestTimer_StartTimer(t *testing.T) {

--- a/statsd/timing_test.go
+++ b/statsd/timing_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/goose/statsd/mocks"
+	"github.com/Shopify/goose/v2/statsd/mocks"
 )
 
 func TestTiming(t *testing.T) {

--- a/syncio/buffer_test.go
+++ b/syncio/buffer_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	. "github.com/Shopify/goose/syncio"
+	. "github.com/Shopify/goose/v2/syncio"
 )
 
 const N = 10000       // make this bigger for a larger (and slower) test


### PR DESCRIPTION
- [ ] https://github.com/Shopify/goose/pull/167
- [ ] https://github.com/Shopify/goose/pull/168
- [ ] https://github.com/Shopify/goose/pull/169
- [ ] https://github.com/Shopify/goose/pull/170

In no particular order:
- [ ] Get rid of global state
    - [ ] Inject Statsd backend
- [ ] Get rid of the `Logger` type
    - [ ] replace Global Fields -> Global client with fields
- [ ] Convert `ContextLog` to a logrus hook
- [ ] Extend `LoggableError` with Fault
- [ ] HTTP errors
    - [ ] Have an internal error for debugging purposes, and an external error with a message or status code.
- [ ] compare errors and fault from go-npt and open something similar in goose
- [ ] stats tag for errors