### PR TITLE
v2 logger

### DIFF
--- a/logger/configure.go
+++ b/logger/configure.go
@@ -36,9 +36,7 @@ func DuplicateLogger(source *logrus.Logger) *logrus.Logger {
 	logger.SetReportCaller(source.ReportCaller)
 
 	for level, hooks := range logger.Hooks {
-		for _, hook := range hooks {
-			logger.Hooks[level] = append(logger.Hooks[level], hook)
-		}
+		logger.Hooks[level] = append(logger.Hooks[level], hooks...)
 	}
 
 	return logger

--- a/logger/configure.go
+++ b/logger/configure.go
@@ -1,0 +1,45 @@
+package logger
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	defaultLogger     *logrus.Logger
+	defaultLoggerOnce sync.Once
+)
+
+func RegisterStandardLoggerHook() {
+	RegisterHook(logrus.StandardLogger())
+}
+
+func RegisterHook(logger *logrus.Logger) {
+	logger.AddHook(defaultHook)
+}
+
+func DefaultLogger() *logrus.Logger {
+	defaultLoggerOnce.Do(func() {
+		defaultLogger = DuplicateLogger(logrus.StandardLogger())
+		defaultLogger.AddHook(defaultHook)
+	})
+
+	return defaultLogger
+}
+
+func DuplicateLogger(source *logrus.Logger) *logrus.Logger {
+	logger := logrus.New()
+	logger.SetOutput(source.Out)
+	logger.SetFormatter(source.Formatter)
+	logger.SetLevel(source.Level)
+	logger.SetReportCaller(source.ReportCaller)
+
+	for level, hooks := range logger.Hooks {
+		for _, hook := range hooks {
+			logger.Hooks[level] = append(logger.Hooks[level], hook)
+		}
+	}
+
+	return logger
+}

--- a/logger/hook.go
+++ b/logger/hook.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"errors"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/logger/hook.go
+++ b/logger/hook.go
@@ -1,0 +1,38 @@
+package logger
+
+import (
+	"errors"
+	"github.com/sirupsen/logrus"
+)
+
+var defaultHook hook
+var GlobalFields = logrus.Fields{}
+
+type hook struct{}
+
+func (h hook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h hook) Fire(entry *logrus.Entry) error {
+	for k, v := range GlobalFields {
+		entry.Data[k] = v
+	}
+
+	if entry.Context != nil {
+		for k, v := range GetLoggableValues(entry.Context) {
+			entry.Data[k] = v
+		}
+	}
+
+	if err, ok := entry.Data[logrus.ErrorKey].(error); ok {
+		var loggable loggableError
+		if errors.As(err, &loggable) {
+			for k, v := range loggable.LogFields() {
+				entry.Data[k] = v
+			}
+		}
+	}
+
+	return nil
+}

--- a/logger/loggable.go
+++ b/logger/loggable.go
@@ -17,11 +17,6 @@ type Loggable interface {
 	LogFields() logrus.Fields
 }
 
-// Valuer is essentially a Context, but down-scoped to what Loggable expects
-type Valuer interface {
-	Value(key interface{}) interface{}
-}
-
 type keyValueContext struct {
 	context.Context
 	key   string
@@ -81,7 +76,7 @@ func WatchingLoggable(ctx context.Context, l Loggable) context.Context {
 }
 
 // GetLoggableValue returns the value of the metadata currently attached to the Context.
-func GetLoggableValue(ctx Valuer, key string) interface{} {
+func GetLoggableValue(ctx context.Context, key string) interface{} {
 	fields := GetLoggableValues(ctx)
 	if v, ok := fields[key]; ok {
 		return v
@@ -89,7 +84,7 @@ func GetLoggableValue(ctx Valuer, key string) interface{} {
 	return nil
 }
 
-func GetLoggableValues(ctx Valuer) logrus.Fields {
+func GetLoggableValues(ctx context.Context) logrus.Fields {
 	if ctx != nil {
 		fields, _ := ctx.Value(logFieldsKey).(logrus.Fields)
 		if fields != nil {

--- a/logger/loggable.go
+++ b/logger/loggable.go
@@ -6,11 +6,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// This create a private key-space in the Context, meaning that only this package can get or set "contextKey" types
-type contextKey struct{}
+type logFieldsKeyType struct{}
 
 var (
-	logFieldsKey = contextKey{}
+	logFieldsKey = logFieldsKeyType{}
 )
 
 type Loggable interface {

--- a/logger/loggable_test.go
+++ b/logger/loggable_test.go
@@ -61,7 +61,7 @@ func ExampleWatchingLoggable() {
 func TestEmptyContext(t *testing.T) {
 	ctx := context.Background()
 	// Using a basic type on purpose, disable linter
-	ctx = context.WithValue(ctx, "a", "b")
+	ctx = context.WithValue(ctx, "a", "b") //nolint:revive,staticcheck
 	// Not showing up in logs
 	checkData(ctx, t, logrus.Fields{})
 }

--- a/logger/loggable_test.go
+++ b/logger/loggable_test.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -10,68 +9,65 @@ import (
 )
 
 func ExampleWithField() {
-	ctx := context.Background()
+	ctx := withStdoutLogger(context.Background()) // Optional
+
 	ctx = WithField(ctx, "foo", "bar")
 
-	log := New("testing")
-
-	// Typically called as log(ctx, nil).Debug("the message")
-	entry := log(ctx, nil)
-	fmt.Printf("%+v", entry.Data["foo"])
+	log := New("testing") // Package-global
+	log(ctx).Info("example")
 
 	// Output:
-	// bar
+	// level=info msg=example component=testing foo=bar
 }
 
 func ExampleWithFields() {
-	ctx := context.Background()
+	ctx := withStdoutLogger(context.Background()) // Optional
+
 	ctx = WithFields(ctx, logrus.Fields{
 		"foo": "bar",
 	})
 
-	log := New("testing")
-
-	// Typically called as log(ctx, nil).Debug("the message")
-	entry := log(ctx, nil)
-	fmt.Printf("%+v", entry.Data["foo"])
+	log := New("testing") // Package-global
+	log(ctx).Info("example")
 
 	// Output:
-	// bar
+	// level=info msg=example component=testing foo=bar
 }
 
-type exampleLoggable logrus.Fields
+type exampleLoggable struct {
+	name string
+}
 
 func (l exampleLoggable) LogFields() logrus.Fields {
-	return logrus.Fields(l)
+	return logrus.Fields{
+		"name": l.name,
+	}
 }
 
 func ExampleWatchingLoggable() {
-	loggable := &exampleLoggable{"foo": "bar"}
+	ctx := withStdoutLogger(context.Background()) // Optional
 
-	ctx := context.Background()
+	loggable := &exampleLoggable{name: "foo"}
+
 	ctx = WatchingLoggable(ctx, loggable)
 
-	log := New("testing")
-
-	// Typically called as log(ctx, nil).Debug("the message")
-	entry := log(ctx, nil)
-	fmt.Printf("%+v", entry.Data["foo"])
+	log := New("testing") // Package-global
+	log(ctx).Info("example")
 
 	// Output:
-	// bar
+	// level=info msg=example component=testing name=foo
 }
 
 func TestEmptyContext(t *testing.T) {
 	ctx := context.Background()
 	// Using a basic type on purpose, disable linter
-	ctx = context.WithValue(ctx, "a", "b") //nolint:revive,staticcheck
+	ctx = context.WithValue(ctx, "a", "b")
 	// Not showing up in logs
-	checkData(ctx, t, logrus.Fields{"component": "testing"})
+	checkData(ctx, t, logrus.Fields{})
 }
 
 func TestWithFields(t *testing.T) {
-	// Test that passing nil doesn't actually crash it, disable the linter
-	ctx := WithFields(nil, logrus.Fields{"a": "b", "c": "d"}) //nolint:golint,staticcheck
+	ctx := WithFields(context.Background(), logrus.Fields{"a": "b", "c": "d"})
 	ctx = WithFields(ctx, logrus.Fields{"a": "e", "f": "g"})
 
 	// Test overrides
@@ -193,8 +189,7 @@ func TestWatchingLoggable(t *testing.T) {
 }
 
 func checkData(ctx context.Context, t *testing.T, expected logrus.Fields) {
-	expected["component"] = "testing" // Will always be there
-	assert.Equal(t, expected, New("testing")(ctx, nil).Data)
+	assert.Equal(t, expected, GetLoggableValues(ctx))
 }
 
 func TestGetLoggableValue(t *testing.T) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -14,10 +14,10 @@ type causer interface {
 
 var GlobalFields = logrus.Fields{}
 
-type Logger func(Valuer, ...error) *logrus.Entry
+type Logger func(context.Context, ...error) *logrus.Entry
 
 func New(name string) Logger {
-	return func(ctx Valuer, err ...error) *logrus.Entry {
+	return func(ctx context.Context, err ...error) *logrus.Entry {
 		if len(err) == 1 && err[0] == nil {
 			err = nil
 		}
@@ -30,7 +30,7 @@ type loggableError interface {
 	Loggable
 }
 
-func ContextLog(ctx Valuer, err []error, entry *logrus.Entry) *logrus.Entry {
+func ContextLog(ctx context.Context, err []error, entry *logrus.Entry) *logrus.Entry {
 	if entry == nil {
 		entry = logrus.NewEntry(logrus.StandardLogger())
 	}
@@ -38,9 +38,7 @@ func ContextLog(ctx Valuer, err []error, entry *logrus.Entry) *logrus.Entry {
 
 	if ctx != nil {
 		entry = entry.WithFields(GetLoggableValues(ctx))
-		if ctx, ok := ctx.(context.Context); ok {
-			entry = entry.WithContext(ctx)
-		}
+		entry = entry.WithContext(ctx)
 	}
 
 	if len(err) != 0 {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -31,7 +31,8 @@ func FromContext(ctx context.Context) FieldLogger {
 
 type FieldLogger interface {
 	logrus.FieldLogger
-	WithContext(ctx context.Context) *logrus.Entry // Unfortunately, logrus' signature returns a *logrus.Entry, so we can't return a FieldLogger
+	// WithContext Unfortunately, logrus' signature returns a *logrus.Entry, so we can't return a FieldLogger
+	WithContext(ctx context.Context) *logrus.Entry
 }
 
 type Logger func(context.Context, ...error) *logrus.Entry

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"bytes"
 	"context"
+	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -10,23 +11,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type contextKeyType string
-
-func buildLogger() (Logger, *bytes.Buffer) {
-	buf := bytes.NewBuffer(nil)
-	logrusLogger := logrus.New()
-	logrusLogger.Out = buf
-	logrusLogger.Formatter = &logrus.TextFormatter{
+func withStdoutLogger(ctx context.Context) context.Context {
+	logger := logrus.New()
+	logger.Out = os.Stdout
+	logger.Formatter = &logrus.TextFormatter{
 		DisableColors:    true,
 		DisableTimestamp: true,
 	}
-	entry := logrus.NewEntry(logrusLogger)
 
-	logger := func(ctx context.Context, err ...error) *logrus.Entry {
-		return ContextLog(ctx, err, entry)
+	RegisterHook(logger)
+	return WithLogger(ctx, logger)
+}
+
+func withBufLogger(ctx context.Context) (context.Context, *bytes.Buffer) {
+	buf := new(bytes.Buffer)
+	logger := logrus.New()
+	logger.Out = buf
+	logger.Formatter = &logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
 	}
 
-	return logger, buf
+	RegisterHook(logger)
+	return WithLogger(ctx, logger), buf
 }
 
 type logFieldsErr struct {
@@ -43,63 +50,39 @@ func (e *logFieldsErr) Error() string {
 }
 
 func TestNew_OptionalErr(t *testing.T) {
-	origGlobal := logrus.Fields{}
-	for k, v := range GlobalFields {
-		origGlobal[k] = v
-	}
-	defer func() { GlobalFields = origGlobal }()
+	ctx := context.Background()
+	log := New("foo")
 
 	t.Run("with err", func(t *testing.T) {
-		logger := New("foo")
-		ctx := context.Background()
+		ctx, buf := withBufLogger(ctx)
 		err := errors.New("bad stuff")
+		log(ctx, err).WithField("a", "b").Info("test")
 
-		entry := logger(ctx, err).WithField("a", "b")
-
-		assert.Equal(t, logrus.Fields{
-			"component": "foo",
-			"a":         "b",
-			"error":     err,
-		}, entry.Data)
+		assert.Equal(t, "level=info msg=test a=b component=foo error=\"bad stuff\"\n", buf.String())
 	})
 
 	t.Run("err with fields", func(t *testing.T) {
-		logger := New("foo")
-		ctx := context.Background()
+		ctx, buf := withBufLogger(ctx)
 		cause := &logFieldsErr{"bad stuff", logrus.Fields{"foo": "bar", "baz": "qux"}}
 		err := errors.Wrap(cause, "cause")
+		log(ctx, err).WithField("a", "b").Info("test")
 
-		entry := logger(ctx, err).WithField("a", "b")
-
-		assert.Equal(t, logrus.Fields{
-			"component": "foo",
-			"a":         "b",
-			"foo":       "bar",
-			"baz":       "qux",
-			"error":     err,
-		}, entry.Data)
+		assert.Equal(t, "level=info msg=test a=b baz=qux component=foo error=\"cause: bad stuff\" foo=bar\n", buf.String())
 	})
 
 	t.Run("without err", func(t *testing.T) {
-		logger := New("foo")
-		ctx := context.Background()
-		entry := logger(ctx).WithField("a", "b")
-		assert.Equal(t, logrus.Fields{
-			"component": "foo",
-			"a":         "b",
-		}, entry.Data)
+		ctx, buf := withBufLogger(ctx)
+		log(ctx).WithField("a", "b").Info("test")
+		assert.Equal(t, "level=info msg=test a=b component=foo\n", buf.String())
 	})
 
 	t.Run("with 2 errors", func(t *testing.T) {
-		logger := New("foo")
-		ctx := context.Background()
+		ctx, buf := withBufLogger(ctx)
 		err1 := errors.New("bad stuff")
 		err2 := errors.New("also bad stuff")
+		log(ctx, err1, err2).WithField("a", "b").Info("test")
 
-		entry := logger(ctx, err1, err2).WithField("a", "b")
-
-		assert.Equal(t, "b", entry.Data["a"])
-		assert.EqualError(t, entry.Data["error"].(error), "bad stuff\nalso bad stuff")
+		assert.Equal(t, "level=info msg=test a=b component=foo error=\"bad stuff\\nalso bad stuff\"\n", buf.String())
 	})
 }
 
@@ -110,42 +93,40 @@ func TestContextLog(t *testing.T) {
 	}
 	defer func() { GlobalFields = origGlobal }()
 
-	logger := New("foo")
+	log := New("foo")
 
 	GlobalFields["testKey"] = "value"
 
-	ctx := context.WithValue(context.Background(), contextKeyType("ctxValue"), "value")
+	ctx := context.Background()
+	ctx, buf := withBufLogger(ctx)
 
 	ctx = WithField(ctx, "bar", "baz")
-	entry := logger(ctx, nil).WithField("a", "b")
-	assert.Equal(t, logrus.Fields{
-		"component": "foo",
-		"bar":       "baz",
-		"a":         "b",
-		"testKey":   "value",
-	}, entry.Data)
-	assert.Equal(t, ctx, entry.Context)
+	log(ctx).WithField("a", "b").Info("test")
+	assert.Equal(t, "level=info msg=test a=b bar=baz component=foo testKey=value\n", buf.String())
 }
 
 func TestLogIfError(t *testing.T) {
 	ctx := context.Background()
-	{
-		logger, buf := buildLogger()
+
+	t.Run("no error", func(t *testing.T) {
+		ctx, buf := withBufLogger(ctx)
 		fn := func() error { return nil }
-		LogIfError(ctx, fn, logger, "")
+		LogIfError(ctx, fn, nil, "")
 		assert.Equal(t, "", buf.String())
-	}
-	{
-		logger, buf := buildLogger()
+	})
+
+	t.Run("error", func(t *testing.T) {
+		ctx, buf := withBufLogger(ctx)
 		fn := func() error { return errors.New("foo") }
-		LogIfError(ctx, fn, logger, "msg")
+		LogIfError(ctx, fn, nil, "msg")
 		assert.Equal(t, "level=error msg=msg error=foo\n", buf.String())
-	}
-	{
-		logger, buf := buildLogger()
+	})
+
+	t.Run("error with context field", func(t *testing.T) {
+		ctx, buf := withBufLogger(ctx)
 		fn := func() error { return errors.New("foo") }
-		ctx := WithField(ctx, "test", "bar")
-		LogIfError(ctx, fn, logger, "msg")
+		ctx = WithField(ctx, "test", "bar")
+		LogIfError(ctx, fn, nil, "msg")
 		assert.Equal(t, "level=error msg=msg error=foo test=bar\n", buf.String())
-	}
+	})
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -22,7 +22,7 @@ func buildLogger() (Logger, *bytes.Buffer) {
 	}
 	entry := logrus.NewEntry(logrusLogger)
 
-	logger := func(ctx Valuer, err ...error) *logrus.Entry {
+	logger := func(ctx context.Context, err ...error) *logrus.Entry {
 		return ContextLog(ctx, err, entry)
 	}
 

--- a/srvutil/request_test.go
+++ b/srvutil/request_test.go
@@ -15,12 +15,12 @@ import (
 func TestBuildContext(t *testing.T) {
 	r := newTestRequest("/path")
 	ctx, id := BuildContext(r)
-	entry := logger.ContextLog(ctx, nil, nil)
+	fields := logger.GetLoggableValues(ctx)
 
 	assert.NotEmpty(t, id)
-	assert.Equal(t, id, entry.Data[logger.UUIDKey])
-	assert.Equal(t, "/path", entry.Data[PathKey])
-	assert.Nil(t, entry.Data[RouteKey]) // No route info
+	assert.Equal(t, id, fields[logger.UUIDKey])
+	assert.Equal(t, "/path", fields[PathKey])
+	assert.Nil(t, fields[RouteKey]) // No route info
 }
 
 func TestRequestContextMiddleware(t *testing.T) {


### PR DESCRIPTION
Significant refactor of the `logger` package.

## Design principles / Motivation

The behaviour added by this package should be available outside of this package (via hooks), but it shouldn't force its registration globally.

## New features

1. Is it now possible to register a Hook on the logrus StandardLogger, such that the field extraction behaviour can be available.
2. It is now possible to attach a logger on a context, such that the global loggers or the package loggers to not have to be overridden when testing
3. A `DuplicateLogger` is now available to facilitate duplicating a logrus.Logger

## Breaking changes

1. `Valuer` is removed in favour of the ubiquitous `context.Context`
2. Remove support for `errors.Cause`, using `errors.Join` from go 1.20 instead.

## Minor changes

1. Change log-based tests to use text output where it made sense or otherwise remove them
