### PR TITLE
Remove the TagLoggable tooling

### DIFF
--- a/srvutil/metrics_observer.go
+++ b/srvutil/metrics_observer.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Shopify/goose/logger"
 	"github.com/Shopify/goose/metrics"
 	"github.com/Shopify/goose/redact"
 	"github.com/Shopify/goose/statsd"
@@ -29,10 +30,13 @@ func (o *DefaultRequestObserver) BeforeRequest(r *http.Request) {
 func (o *DefaultRequestObserver) AfterRequest(r *http.Request, recorder HTTPRecorder, requestDuration time.Duration) {
 	ctx := r.Context()
 
-	ctx = statsd.WithTagLogFields(ctx, statsd.Tags{
+	fields := map[string]interface{}{
 		"statusCode":  recorder.StatusCode(),
 		"statusClass": fmt.Sprintf("%dxx", recorder.StatusCode()/100), // 2xx, 5xx, etc.
-	})
+	}
+
+	ctx = statsd.WithTags(ctx, fields)
+	ctx = logger.WithFields(ctx, fields)
 
 	metrics.HTTPRequest.Duration(ctx, requestDuration)
 

--- a/statsd/taggable.go
+++ b/statsd/taggable.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-
-	"github.com/Shopify/goose/logger"
 )
 
 // This create a private key-space in the Context, meaning that only this package can get or set "contextKey" types
@@ -81,49 +79,6 @@ func WithTaggable(ctx context.Context, t Taggable) context.Context {
 // When a metric is recorded, StatsTags() will be called and the tags will be appended.
 func WatchingTaggable(ctx context.Context, t Taggable) context.Context {
 	return &taggableContext{Context: ctx, taggable: t}
-}
-
-// WithTagLogFields combines logger.WithFields(fields) and WithTags(tags)
-// This simplifies the common operation of adding fields to the logger and the metrics
-// This argument purposefully not typed as Tags, such that logrus.Fields and Tags can both be passed without additional casting.
-func WithTagLogFields(ctx context.Context, tags map[string]interface{}) context.Context {
-	ctx = logger.WithFields(ctx, tags)
-	ctx = WithTags(ctx, tags)
-	return ctx
-}
-
-// WithTagLoggable combines WithTaggable and logger.WithLoggable
-// If the Loggable is a Taggable already (implements StatsTags), it will be used directly.
-// If StatsTags doesn't exist, LogFields() will be used instead.
-func WithTagLoggable(ctx context.Context, l logger.Loggable) context.Context {
-	ctx = logger.WithLoggable(ctx, l)
-	if taggable, ok := l.(Taggable); ok {
-		ctx = WithTaggable(ctx, taggable)
-	} else {
-		ctx = WithTaggable(ctx, tagLoggable{l})
-	}
-	return ctx
-}
-
-type tagLoggable struct {
-	logger.Loggable
-}
-
-func (l tagLoggable) StatsTags() Tags {
-	return Tags(l.LogFields())
-}
-
-// WatchingTagLoggable combines WatchingTaggable and logger.WatchingLoggable
-// If the Loggable is a Taggable already (implements StatsTags), it will be used directly.
-// If StatsTags doesn't exist, LogFields() will be used instead.
-func WatchingTagLoggable(ctx context.Context, l logger.Loggable) context.Context {
-	ctx = logger.WatchingLoggable(ctx, l)
-	if taggable, ok := l.(Taggable); ok {
-		ctx = WatchingTaggable(ctx, taggable)
-	} else {
-		ctx = WatchingTaggable(ctx, tagLoggable{l})
-	}
-	return ctx
 }
 
 // getStatsTags returns the merged tags as a list

--- a/statsd/taggable_test.go
+++ b/statsd/taggable_test.go
@@ -3,13 +3,9 @@ package statsd
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/Shopify/goose/logger"
 )
 
 var exampleBackend = NewForwardingBackend(func(_ context.Context, mType string, name string, value interface{}, tags []string, _ float64) error {
@@ -21,16 +17,6 @@ type testTaggable Tags
 
 func (t *testTaggable) StatsTags() Tags {
 	return Tags(*t)
-}
-
-type testLoggable logrus.Fields
-
-func (l *testLoggable) LogFields() logrus.Fields {
-	return logrus.Fields(*l)
-}
-
-func (l *testLoggable) StatsTags() Tags {
-	return SelectKeys(l.LogFields(), "testField")
 }
 
 func ExampleWithTags() {
@@ -59,33 +45,6 @@ func ExampleWatchingTaggable() {
 
 	// Output:
 	// count: page.view: 10 [email:unknown user:anonymous]
-}
-
-func ExampleSelectKeys() {
-	// <setup for example>
-	logrusLogger := logrus.New()
-	logrusLogger.Out = os.Stdout
-	logrusLogger.Formatter = &logrus.TextFormatter{
-		DisableColors:    true,
-		DisableTimestamp: true,
-	}
-	entry := logrus.NewEntry(logrusLogger)
-	SetBackend(exampleBackend)
-	// </setup for example>
-
-	session := &testLoggable{"foo": "bar", "testField": "test"}
-
-	ctx := context.Background()
-	ctx = WithTagLoggable(ctx, session)
-
-	metric := &Counter{Name: "page.view"}
-	metric.Count(ctx, 10)
-
-	logger.ContextLog(ctx, nil, entry).Info("example")
-
-	// Output:
-	// count: page.view: 10 [testField:test]
-	// level=info msg=example foo=bar testField=test
 }
 
 func TestEmptyContext(t *testing.T) {


### PR DESCRIPTION
Remove the TagLoggable methods: `statsd.WithTagLogFields`, `statsd.WithTagLoggable`, `statsd.WatchingTagLoggable`.

This API is confusing and the caller can do the same thing by calling both `statsd` and `logger`.

`WithTagLoggable` is even harmful since it will happily add log fields as metric tags.