### PR TITLE
Enable Bugsnag Proxy for Observe Error Management Beta

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,7 @@ jobs:
         go-version: 1.15.x
 
     - name: Cache
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -72,7 +72,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Cache
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,12 +38,8 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/Shopify/goose
-  golint:
-    min-confidence: 0
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
   gosec:
     excludes:
       - G115

--- a/bugsnag/bugsnagger.go
+++ b/bugsnag/bugsnagger.go
@@ -211,9 +211,9 @@ func httpRequestMiddleware(event *bugsnaggo.Event, config *bugsnaggo.Configurati
 }
 
 func (snagger *bugsnagger) Setup(apiKey string, commit string, env string, packages []string) {
-	// Add the bugsnag package and it's folder location on disk to bugsnag's ProjectPackages.
-	// This will ensure that Notify calls from bugsnagger.go will always share the same file name
-	// and will retain grouping across Shopify/goose dependency upgrades.
+	// Add the bugsnag package and its folder location on disk to Bugsnag's ProjectPackages.
+	// This ensures Notify calls from bugsnagger.go always share the same file name
+	// and retain grouping across Shopify/goose dependency upgrades.
 	packages = append(packages, "main*", "github.com/Shopify/goose/bugsnag")
 	if _, file, _, ok := runtime.Caller(0); ok {
 		gooseMod := strings.TrimSuffix(file, "bugsnag/bugsnagger.go")
@@ -228,6 +228,10 @@ func (snagger *bugsnagger) Setup(apiKey string, commit string, env string, packa
 		ReleaseStage:    env,
 		Synchronous:     true,
 		PanicHandler:    panicHandler,
+		Endpoints: bugsnaggo.Endpoints{
+			Notify:   "https://error-analytics-production.shopifysvc.com",
+			Sessions: "https://error-analytics-sessions-production.shopifysvc.com",
+		},
 	})
 }
 

--- a/bugsnag/bugsnagger.go
+++ b/bugsnag/bugsnagger.go
@@ -210,7 +210,28 @@ func httpRequestMiddleware(event *bugsnaggo.Event, config *bugsnaggo.Configurati
 	return nil
 }
 
-func (snagger *bugsnagger) Setup(apiKey string, commit string, env string, packages []string) {
+type bugsnagOpts struct {
+	endpoints bugsnaggo.Endpoints
+}
+
+type BugsnaggerOption func(opts *bugsnagOpts)
+
+// WithEndpoints sets the endpoints for the bugsnag client
+func WithEndpoints(notifier bugsnaggo.Endpoints) BugsnaggerOption {
+	return func(opts *bugsnagOpts) {
+		opts.endpoints = notifier
+	}
+}
+
+// Setup initializes the bugsnag client with the given API key, commit, environment, and packages.
+// By default, it will use the endpoints for Shopify internal error analytics service.
+func (snagger *bugsnagger) Setup(
+	apiKey string,
+	commit string,
+	env string,
+	packages []string,
+	opts ...BugsnaggerOption,
+) {
 	// Add the bugsnag package and its folder location on disk to Bugsnag's ProjectPackages.
 	// This ensures Notify calls from bugsnagger.go always share the same file name
 	// and retain grouping across Shopify/goose dependency upgrades.
@@ -218,6 +239,17 @@ func (snagger *bugsnagger) Setup(apiKey string, commit string, env string, packa
 	if _, file, _, ok := runtime.Caller(0); ok {
 		gooseMod := strings.TrimSuffix(file, "bugsnag/bugsnagger.go")
 		packages = append(packages, gooseMod+"*")
+	}
+
+	var bo = &bugsnagOpts{
+		endpoints: bugsnaggo.Endpoints{
+			Notify:   "https://error-analytics-production.shopifysvc.com",
+			Sessions: "https://error-analytics-sessions-production.shopifysvc.com",
+		},
+	}
+
+	for _, opt := range opts {
+		opt(bo)
 	}
 
 	bugsnaggo.OnBeforeNotify(httpRequestMiddleware)
@@ -228,10 +260,7 @@ func (snagger *bugsnagger) Setup(apiKey string, commit string, env string, packa
 		ReleaseStage:    env,
 		Synchronous:     true,
 		PanicHandler:    panicHandler,
-		Endpoints: bugsnaggo.Endpoints{
-			Notify:   "https://error-analytics-production.shopifysvc.com",
-			Sessions: "https://error-analytics-sessions-production.shopifysvc.com",
-		},
+		Endpoints:       bo.endpoints,
 	})
 }
 


### PR DESCRIPTION
From [Observe Error Management Beta Announcement](https://vault.shopify.io/posts/285323) Bugsnag is being sunset May 31st, 2025. The solution is to send error data to the proxy which will route to both Bugsnag (until the sunset date) and Observe.

An example from cloudbuddies which uses Go: https://github.com/Shopify/cloudbuddies/pull/7409

This is used in two places:

[production-registry](https://github.com/Shopify/production-registry/blob/0335029f54797382a5e8b0aa63ef1a2fa179a94e/pkg/utils/bugsnag.go#L7)

[opentelemetry-collector-shopify](https://github.com/Shopify/opentelemetry-collector-shopify/blob/e7e2222c535b3edd18e4434184b896c738e7a281/exporter/googlecloudpubsubliteexporter/exporter.go#L28)

